### PR TITLE
Add LSP symbol kind for filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,18 @@ IWE functions in two modes:
 
 Please visit [IWE.md](https://iwe.md) for more information.
 
+## Get Involved
+
+IWE fully depends on community support, which is essential for its growth and development. We encourage you to participate in [discussions](https://github.com/iwe-org/iwe/discussions) and report any [issues](https://github.com/iwe-org/iwe/issues) you encounter.
+
+## Debug Mode
+
+IWE includes a debug mode, which can be enabled by setting the `IWE_DEBUG` environment variable. In debug mode, IWE LSP will generate a detailed log file named `iwe.log` in the directory where you started it. Including logs with your [issue](https://github.com/iwe-org/iwe/issues) report will help us to resolve it faster.
+
+```
+export IWE_DEBUG=true; nvim
+```
+
 ## Inspired by many other open-source projects
 
 - [zk notes](https://github.com/zk-org/zk)

--- a/crates/iwe/src/main.rs
+++ b/crates/iwe/src/main.rs
@@ -54,7 +54,10 @@ struct Squash {
 }
 
 #[derive(Debug, Args)]
-struct Paths {}
+struct Paths {
+    #[clap(long, short, global = true, required = false, default_value = "4")]
+    depth: u8,
+}
 
 #[derive(Debug, Args)]
 struct GlobalOpts {
@@ -128,8 +131,10 @@ fn paths_command(args: Paths) {
     graph
         .paths()
         .iter()
+        .filter(|n| n.ids().len() <= args.depth as usize)
         .map(|n| render(&n, &graph))
         .sorted()
+        .unique()
         .for_each(|string| println!("{}", string));
 }
 

--- a/crates/iwes/src/router/server/extensions.rs
+++ b/crates/iwes/src/router/server/extensions.rs
@@ -260,9 +260,15 @@ pub impl NodePath {
         let target = self.target();
         let line = context.node_line_number(target).unwrap_or(0);
 
+        let kind = if self.ids().len() == 1 {
+            SymbolKind::NAMESPACE
+        } else {
+            SymbolKind::OBJECT
+        };
+
         SymbolInformation {
             name: self.render(context),
-            kind: SymbolKind::OBJECT,
+            kind,
             deprecated: None,
             tags: None,
             location: Location {

--- a/crates/iwes/tests/did_change_test.rs
+++ b/crates/iwes/tests/did_change_test.rs
@@ -37,7 +37,7 @@ fn did_change_test_once() {
             query: "".to_string(),
         },
         WorkspaceSymbolResponse::Flat(vec![SymbolInformation {
-            kind: lsp_types::SymbolKind::OBJECT,
+            kind: lsp_types::SymbolKind::NAMESPACE,
             location: lsp_types::Location {
                 uri: uri(1),
                 range: Range::new(Position::new(0, 0), Position::new(1, 0)),
@@ -74,7 +74,7 @@ fn new_file() {
             query: "".to_string(),
         },
         WorkspaceSymbolResponse::Flat(vec![SymbolInformation {
-            kind: lsp_types::SymbolKind::OBJECT,
+            kind: lsp_types::SymbolKind::NAMESPACE,
             location: lsp_types::Location {
                 uri: uri(2),
                 range: Range::new(Position::new(0, 0), Position::new(1, 0)),
@@ -125,7 +125,7 @@ fn did_change_test_two_times() {
             query: "".to_string(),
         },
         WorkspaceSymbolResponse::Flat(vec![SymbolInformation {
-            kind: lsp_types::SymbolKind::OBJECT,
+            kind: lsp_types::SymbolKind::NAMESPACE,
             location: lsp_types::Location {
                 uri: uri(1),
                 range: Range::new(Position::new(0, 0), Position::new(1, 0)),

--- a/crates/iwes/tests/did_save_test.rs
+++ b/crates/iwes/tests/did_save_test.rs
@@ -29,7 +29,7 @@ fn did_save_test_once() {
             query: "".to_string(),
         },
         WorkspaceSymbolResponse::Flat(vec![SymbolInformation {
-            kind: lsp_types::SymbolKind::OBJECT,
+            kind: lsp_types::SymbolKind::NAMESPACE,
             location: lsp_types::Location {
                 uri: uri(1),
                 range: Range::new(Position::new(0, 0), Position::new(1, 0)),
@@ -59,7 +59,7 @@ fn new_file() {
             query: "".to_string(),
         },
         WorkspaceSymbolResponse::Flat(vec![SymbolInformation {
-            kind: lsp_types::SymbolKind::OBJECT,
+            kind: lsp_types::SymbolKind::NAMESPACE,
             location: lsp_types::Location {
                 uri: uri(2),
                 range: Range::new(Position::new(0, 0), Position::new(1, 0)),
@@ -96,7 +96,7 @@ fn did_save_test_two_times() {
             query: "".to_string(),
         },
         WorkspaceSymbolResponse::Flat(vec![SymbolInformation {
-            kind: lsp_types::SymbolKind::OBJECT,
+            kind: lsp_types::SymbolKind::NAMESPACE,
             location: lsp_types::Location {
                 uri: uri(1),
                 range: Range::new(Position::new(0, 0), Position::new(1, 0)),

--- a/crates/iwes/tests/format_document_test.rs
+++ b/crates/iwes/tests/format_document_test.rs
@@ -69,6 +69,24 @@ fn update_ref_titles() {
 }
 
 #[test]
+fn format_extension() {
+    assert_formatted_with_extension(
+        indoc! {"
+            # test
+
+            [title](2.md)
+            _
+            # title
+            "},
+        indoc! {"
+            # test
+
+            [title](2.md)
+        "},
+    );
+}
+
+#[test]
 fn update_link_titles() {
     assert_formatted(
         indoc! {"
@@ -123,6 +141,27 @@ fn updte_ref_titles_after_new_file_change() {
 }
 fn assert_formatted(source: &str, formatted: &str) {
     let fixture = Fixture::with(source);
+
+    fixture.format_doucment(
+        DocumentFormattingParams {
+            text_document: TextDocumentIdentifier { uri: uri(1) },
+            options: Default::default(),
+            work_done_progress_params: Default::default(),
+        },
+        vec![TextEdit {
+            range: Range::new(Position::new(0, 0), Position::new(u32::MAX, 0)),
+            new_text: formatted.to_string(),
+        }],
+    )
+}
+
+fn assert_formatted_with_extension(source: &str, formatted: &str) {
+    let fixture = Fixture::with_options(
+        source,
+        liwe::model::graph::MarkdownOptions {
+            refs_extension: ".md".to_string(),
+        },
+    );
 
     fixture.format_doucment(
         DocumentFormattingParams {

--- a/crates/iwes/tests/workspace_symbols_test.rs
+++ b/crates/iwes/tests/workspace_symbols_test.rs
@@ -24,7 +24,7 @@ fn one_file() {
         },
         WorkspaceSymbolResponse::Flat(vec![SymbolInformation {
             name: "test".to_string(),
-            kind: lsp_types::SymbolKind::OBJECT,
+            kind: lsp_types::SymbolKind::NAMESPACE,
             location: lsp_types::Location {
                 uri: uri(1),
                 range: Range::new(Position::new(0, 0), Position::new(1, 0)),
@@ -54,7 +54,7 @@ fn one_file_two_headers() {
         WorkspaceSymbolResponse::Flat(vec![
             SymbolInformation {
                 name: "test".to_string(),
-                kind: lsp_types::SymbolKind::OBJECT,
+                kind: lsp_types::SymbolKind::NAMESPACE,
                 location: lsp_types::Location {
                     uri: uri(1),
                     range: Range::new(Position::new(0, 0), Position::new(1, 0)),
@@ -96,7 +96,7 @@ fn one_file_two_headers_same_level() {
         WorkspaceSymbolResponse::Flat(vec![
             SymbolInformation {
                 name: "test".to_string(),
-                kind: lsp_types::SymbolKind::OBJECT,
+                kind: lsp_types::SymbolKind::NAMESPACE,
                 location: lsp_types::Location {
                     uri: uri(1),
                     range: Range::new(Position::new(0, 0), Position::new(1, 0)),
@@ -107,7 +107,7 @@ fn one_file_two_headers_same_level() {
             },
             SymbolInformation {
                 name: "test 2".to_string(),
-                kind: lsp_types::SymbolKind::OBJECT,
+                kind: lsp_types::SymbolKind::NAMESPACE,
                 location: lsp_types::Location {
                     uri: uri(1),
                     range: Range::new(Position::new(2, 0), Position::new(3, 0)),
@@ -137,7 +137,7 @@ fn two_files() {
         },
         WorkspaceSymbolResponse::Flat(vec![
             SymbolInformation {
-                kind: lsp_types::SymbolKind::OBJECT,
+                kind: lsp_types::SymbolKind::NAMESPACE,
                 location: lsp_types::Location {
                     uri: uri(1),
                     range: Range::new(Position::new(0, 0), Position::new(1, 0)),
@@ -148,7 +148,7 @@ fn two_files() {
                 deprecated: None,
             },
             SymbolInformation {
-                kind: lsp_types::SymbolKind::OBJECT,
+                kind: lsp_types::SymbolKind::NAMESPACE,
                 location: lsp_types::Location {
                     uri: uri(2),
                     range: Range::new(Position::new(0, 0), Position::new(1, 0)),
@@ -192,7 +192,7 @@ fn nested_files() {
                 deprecated: None,
             },
             SymbolInformation {
-                kind: lsp_types::SymbolKind::OBJECT,
+                kind: lsp_types::SymbolKind::NAMESPACE,
                 location: lsp_types::Location {
                     uri: uri(2),
                     range: Range::new(Position::new(0, 0), Position::new(1, 0)),
@@ -251,7 +251,7 @@ fn two_nested_nested_files() {
                 deprecated: None,
             },
             SymbolInformation {
-                kind: lsp_types::SymbolKind::OBJECT,
+                kind: lsp_types::SymbolKind::NAMESPACE,
                 location: lsp_types::Location {
                     uri: uri(3),
                     range: Range::new(Position::new(0, 0), Position::new(1, 0)),


### PR DESCRIPTION
This enables filtering for root notes (which are not included in any other notes) using a command like. 

```
nnoremap <silent> ga <Cmd>lua require('telescope.builtin').lsp_workspace_symbols({ symbols = { "namespace" }})<CR>
```