### PR TITLE
doc: added installation instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# About
+# About IWE
 
 [IWE](https://iwe.md) is a Markdown notes assistant for your favorite text editor. It's a tool that helps you organize your Markdown notes. It treats notes as an interconnected graph, where each document acts as a sub-tree and the links are the edges connecting them. It supports various operations designed to assist with navigating and restructuring the graph.
 
@@ -54,6 +54,45 @@ Please visit [IWE.md](https://iwe.md) for more information and [quick start guid
 ## Command Line Utility Mode
 
 This tool lets you process thousands of documents in just a second. With IWE, you can reformat documents and update link titles across your entire library. You can also use the CLI mode to combine multiple files into one extended document.
+
+## Installation
+
+Installation instructions are below. Editor integration is covered in the [quick start](https://iwe.md/quick-start) section.
+
+### From The AUR
+
+Arch Linux users can install the `iwe-bin` or `iwe-git` packages. They include the `iwe` and `iwes` binaries.
+
+```bash
+# You can use your favorite AUR helper.
+paru -S iwe-bin
+paru -S iwe-git
+```
+
+### From Crates.IO
+
+- Rust and Cargo must be installed on your system. You can get them from [rustup.rs](https://rustup.rs).
+
+IWE is available at [crates.io](https://crates.io/crates/iwe). You can install IWE using cargo (and [iwes](https://crates.io/crates/iwes) for LSP server)
+
+```sh
+cargo install iwe
+cargo install iwes
+```
+
+The binaries will be installed to `$HOME/.cargo/bin`. You may need to add it to your `$PATH`.
+
+### From Source
+
+Clone the repository, navigate into the project directory, and build the project:
+
+```sh
+git clone git@github.com:iwe-org/iwe.git
+cd iwe
+cargo build --release
+```
+
+This will create executables located in the `target/release` directory.
 
 ## Get Involved
 


### PR DESCRIPTION
I added instructions for installing the AUR package, as well as instructions to install via crates.io and from source, to the readme.
