### PR TITLE
feat: better search results

### DIFF
--- a/crates/iwes/tests/workspace_symbols_test.rs
+++ b/crates/iwes/tests/workspace_symbols_test.rs
@@ -265,7 +265,7 @@ fn two_files() {
 
 #[test]
 #[allow(deprecated)]
-fn nested_files() {
+fn two_nested_files() {
     let fixture = Fixture::with(indoc! {"
             # test 1
             _
@@ -309,7 +309,68 @@ fn nested_files() {
 
 #[test]
 #[allow(deprecated)]
-fn two_nested_nested_files() {
+fn page_rank_applied_after_fuzzy_score() {
+    let fixture = Fixture::with(indoc! {"
+            # test rank
+            _
+            # test rank
+            _
+            # another page
+
+            link to [test 1](1)
+
+            link to [test 2](2)
+
+            link to [test 2](2)
+            "});
+
+    fixture.workspace_symbols(
+        WorkspaceSymbolParams {
+            work_done_progress_params: Default::default(),
+            partial_result_params: Default::default(),
+            query: "test".to_string(),
+        },
+        WorkspaceSymbolResponse::Flat(vec![
+            SymbolInformation {
+                kind: lsp_types::SymbolKind::NAMESPACE,
+                location: lsp_types::Location {
+                    uri: uri(2),
+                    range: Range::new(Position::new(0, 0), Position::new(1, 0)),
+                },
+                name: "test rank".to_string(),
+                container_name: None,
+                tags: None,
+                deprecated: None,
+            },
+            SymbolInformation {
+                kind: lsp_types::SymbolKind::NAMESPACE,
+                location: lsp_types::Location {
+                    uri: uri(1),
+                    range: Range::new(Position::new(0, 0), Position::new(1, 0)),
+                },
+                name: "test rank".to_string(),
+                container_name: None,
+                tags: None,
+                deprecated: None,
+            },
+            SymbolInformation {
+                kind: lsp_types::SymbolKind::NAMESPACE,
+                location: lsp_types::Location {
+                    uri: uri(3),
+                    range: Range::new(Position::new(0, 0), Position::new(1, 0)),
+                },
+                name: "another page".to_string(),
+                container_name: None,
+                tags: None,
+                deprecated: None,
+            },
+        ]),
+    )
+}
+
+#[test]
+#[allow(deprecated)]
+fn dual_nested_files() {
     let fixture = Fixture::with(indoc! {"
             # test 1
             _
@@ -332,10 +393,10 @@ fn two_nested_nested_files() {
             SymbolInformation {
                 kind: lsp_types::SymbolKind::OBJECT,
                 location: lsp_types::Location {
-                    uri: uri(1),
+                    uri: uri(2),
                     range: Range::new(Position::new(0, 0), Position::new(1, 0)),
                 },
-                name: "test 3 • test 2 • test 1".to_string(),
+                name: "test 3 • test 2".to_string(),
                 container_name: None,
                 tags: None,
                 deprecated: None,
@@ -343,10 +404,10 @@ fn two_nested_nested_files() {
             SymbolInformation {
                 kind: lsp_types::SymbolKind::OBJECT,
                 location: lsp_types::Location {
-                    uri: uri(2),
+                    uri: uri(1),
                     range: Range::new(Position::new(0, 0), Position::new(1, 0)),
                 },
-                name: "test 3 • test 2".to_string(),
+                name: "test 3 • test 2 • test 1".to_string(),
                 container_name: None,
                 tags: None,
                 deprecated: None,

--- a/crates/liwe/src/database.rs
+++ b/crates/liwe/src/database.rs
@@ -59,8 +59,18 @@ impl Database {
             })
             .collect::<Vec<_>>()
             .into_iter()
-            .sorted_by(|(path_a, a), (path_b, b)| {
-                (b + path_b.node_rank as i64).cmp(&(a + path_a.node_rank as i64))
+            .sorted_by(|(path_a, rank_a), (path_b, rank_b)| {
+                if query.is_empty() {
+                    path_b
+                        .node_rank
+                        .cmp(&path_a.node_rank)
+                        .then_with(|| path_a.search_text.len().cmp(&path_b.search_text.len()))
+                } else {
+                    rank_b
+                        .cmp(&rank_a)
+                        .then_with(|| path_a.search_text.len().cmp(&path_b.search_text.len()))
+                        .then_with(|| path_b.node_rank.cmp(&path_a.node_rank))
+                }
             })
             .map(|(path, _)| path)
             .take(100)


### PR DESCRIPTION
Sort search results by page-rank if query is empty. Sort by fuzzy match score, then length, then rank if query is present