### PR TITLE
Handle textDocument/didOpen

### DIFF
--- a/crates/iwes/src/router.rs
+++ b/crates/iwes/src/router.rs
@@ -8,9 +8,10 @@ use log::{debug, error};
 use lsp_server::{ErrorCode, Message, Request};
 use lsp_server::{Notification, Response};
 use lsp_types::{
-    CodeActionParams, DidChangeTextDocumentParams, DidSaveTextDocumentParams,
-    DocumentFormattingParams, DocumentSymbolParams, InlayHintParams, InlineValueParams,
-    ReferenceParams, RenameParams, TextDocumentPositionParams, WorkspaceSymbolParams,
+    CodeActionParams, DidChangeTextDocumentParams, DidOpenTextDocumentParams,
+    DidSaveTextDocumentParams, DocumentFormattingParams, DocumentSymbolParams, InlayHintParams,
+    InlineValueParams, ReferenceParams, RenameParams, TextDocumentPositionParams,
+    WorkspaceSymbolParams,
 };
 use lsp_types::{CompletionParams, GotoDefinitionParams};
 use serde::Deserialize;
@@ -115,6 +116,9 @@ impl Router {
             ),
             "textDocument/didSave" => self.server.handle_did_save_text_document(
                 DidSaveTextDocumentParams::deserialize(notification.params).unwrap(),
+            ),
+            "textDocument/didOpen" => self.server.handle_did_open_text_document(
+                DidOpenTextDocumentParams::deserialize(notification.params).unwrap(),
             ),
             default => {
                 error!("unhandled notification: {}", default)

--- a/crates/iwes/src/router/server.rs
+++ b/crates/iwes/src/router/server.rs
@@ -102,6 +102,10 @@ impl Server {
         );
     }
 
+    pub fn handle_did_open_text_document(&mut self, _params: DidOpenTextDocumentParams) {
+        // NOP
+    }
+
     pub fn handle_completion(&self, params: CompletionParams) -> CompletionResponse {
         let relative_to = params
             .text_document_position


### PR DESCRIPTION
Helix 25.01.1 (35575b0b) sends didOpen when opening a file and the iwes reported that as an error.

```
2025-03-03T09:07:23.896 helix_lsp::transport [ERROR] iwe err <- "2025-03-03T08:07:23.896068Z  INFO iwes: starting IWE LSP server    \n"
2025-03-03T09:07:23.896 helix_lsp::transport [ERROR] iwe err <- "2025-03-03T08:07:23.896908Z ERROR iwes::router: unhandled notification: textDocument/didOpen    \n"
```

Since IWE does not need to handle the event, I added a simple NOP handler.