### PR TITLE
chore: Fix test on release only target

### DIFF
--- a/crates/iwe/tests/common/mod.rs
+++ b/crates/iwe/tests/common/mod.rs
@@ -1,0 +1,21 @@
+use std::env;
+use std::path::PathBuf;
+
+pub fn get_iwe_binary_path() -> PathBuf {
+    let mut binary_path = env::current_dir().expect("Failed to get current directory");
+
+    while !binary_path.join("Cargo.toml").exists() || !binary_path.join("crates").exists() {
+        if !binary_path.pop() {
+            panic!("Could not find workspace root");
+        }
+    }
+
+    binary_path.push("target");
+
+    ["debug", "release"]
+        .into_iter()
+        .map(|x| binary_path.join(x).join("iwe"))
+        .filter(|x| x.exists())
+        .next()
+        .unwrap_or_else(|| panic!("Could not find iwe binary"))
+}

--- a/crates/iwe/tests/contents_test.rs
+++ b/crates/iwe/tests/contents_test.rs
@@ -1,10 +1,10 @@
 use indoc::indoc;
 use liwe::model::config::{Configuration, LibraryOptions, MarkdownOptions};
-use std::env;
 use std::fs::{create_dir_all, write};
-use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
+
+mod common;
 
 #[test]
 fn test_contents_basic_output() {
@@ -136,7 +136,7 @@ fn test_contents_with_verbose_flag() {
     let temp_dir = setup_test_workspace_with_content();
     let temp_path = temp_dir.path();
 
-    let output = Command::new(get_iwe_binary_path())
+    let output = Command::new(common::get_iwe_binary_path())
         .arg("contents")
         .arg("--verbose")
         .arg("1")
@@ -462,7 +462,7 @@ fn setup_iwe_config(temp_path: &std::path::Path) {
 }
 
 fn run_contents_command(work_dir: &std::path::Path, args: &[&str]) -> std::process::Output {
-    let mut command = Command::new(get_iwe_binary_path());
+    let mut command = Command::new(common::get_iwe_binary_path());
     command.arg("contents").current_dir(work_dir);
 
     for arg in args {
@@ -470,10 +470,4 @@ fn run_contents_command(work_dir: &std::path::Path, args: &[&str]) -> std::proce
     }
 
     command.output().expect("Failed to execute iwe contents")
-}
-
-fn get_iwe_binary_path() -> PathBuf {
-    let current_dir = env::current_dir().expect("Failed to get current directory");
-    let workspace_root = current_dir.parent().unwrap().parent().unwrap();
-    workspace_root.join("target").join("debug").join("iwe")
 }

--- a/crates/iwe/tests/export_dot_test.rs
+++ b/crates/iwe/tests/export_dot_test.rs
@@ -1,10 +1,10 @@
 use indoc::indoc;
 use liwe::model::config::{Configuration, LibraryOptions, MarkdownOptions};
-use std::env;
 use std::fs::{create_dir_all, write};
-use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
+
+mod common;
 
 #[test]
 fn test_export_dot_basic() {
@@ -82,7 +82,7 @@ fn setup_test_workspace() -> TempDir {
 }
 
 fn run_export_dot_command(temp_dir: &TempDir, args: &[&str]) -> std::process::Output {
-    let binary_path = get_binary_path();
+    let binary_path = common::get_iwe_binary_path();
 
     let mut cmd = Command::new(binary_path);
     cmd.current_dir(temp_dir.path()).arg("export").arg("dot");
@@ -92,27 +92,4 @@ fn run_export_dot_command(temp_dir: &TempDir, args: &[&str]) -> std::process::Ou
     }
 
     cmd.output().expect("Failed to execute export dot command")
-}
-
-fn get_binary_path() -> PathBuf {
-    let mut binary_path = env::current_dir().expect("Failed to get current directory");
-
-    while !binary_path.join("Cargo.toml").exists() || !binary_path.join("crates").exists() {
-        if !binary_path.pop() {
-            panic!("Could not find workspace root");
-        }
-    }
-
-    binary_path.push("target");
-
-    let debug_path = binary_path.join("debug").join("iwe");
-    let release_path = binary_path.join("release").join("iwe");
-
-    if debug_path.exists() {
-        debug_path
-    } else if release_path.exists() {
-        release_path
-    } else {
-        panic!("Could not find iwe binary. Run 'cargo build' first.");
-    }
 }

--- a/crates/iwe/tests/init_test.rs
+++ b/crates/iwe/tests/init_test.rs
@@ -1,10 +1,9 @@
 use liwe::model::config::{Configuration, LibraryOptions, MarkdownOptions};
-use std::env;
 use std::fs::{create_dir_all, read_to_string, File};
-
-use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
+
+mod common;
 
 #[test]
 fn test_init_creates_iwe_directory() {
@@ -55,7 +54,7 @@ fn test_init_already_initialized() {
     let output1 = run_init_command(&temp_path);
     assert!(output1.status.success(), "First init should succeed");
 
-    let output2 = Command::new(get_iwe_binary_path())
+    let output2 = Command::new(common::get_iwe_binary_path())
         .arg("init")
         .arg("-v")
         .arg("2")
@@ -80,7 +79,7 @@ fn test_init_existing_iwe_file() {
     let iwe_file = temp_path.join(".iwe");
     File::create(&iwe_file).expect("Should create .iwe file");
 
-    let output = Command::new(get_iwe_binary_path())
+    let output = Command::new(common::get_iwe_binary_path())
         .arg("init")
         .arg("-v")
         .arg("2")
@@ -130,7 +129,7 @@ fn test_init_nested_directory() {
     let nested_path = temp_path.join("nested").join("directory");
     create_dir_all(&nested_path).expect("Should create nested directory");
 
-    let output = Command::new(get_iwe_binary_path())
+    let output = Command::new(common::get_iwe_binary_path())
         .arg("init")
         .current_dir(&nested_path)
         .output()
@@ -157,7 +156,7 @@ fn test_init_with_verbose_flag() {
     let temp_dir = TempDir::new().expect("Failed to create temp directory");
     let temp_path = temp_dir.path();
 
-    let output = Command::new(get_iwe_binary_path())
+    let output = Command::new(common::get_iwe_binary_path())
         .arg("init")
         .arg("--verbose")
         .arg("1")
@@ -213,15 +212,9 @@ fn test_init_preserves_existing_config() {
 }
 
 fn run_init_command(work_dir: &std::path::Path) -> std::process::Output {
-    Command::new(get_iwe_binary_path())
+    Command::new(common::get_iwe_binary_path())
         .arg("init")
         .current_dir(work_dir)
         .output()
         .expect("Failed to execute iwe init")
-}
-
-fn get_iwe_binary_path() -> PathBuf {
-    let current_dir = env::current_dir().expect("Failed to get current directory");
-    let workspace_root = current_dir.parent().unwrap().parent().unwrap();
-    workspace_root.join("target").join("debug").join("iwe")
 }

--- a/crates/iwe/tests/normalize_test.rs
+++ b/crates/iwe/tests/normalize_test.rs
@@ -1,10 +1,10 @@
 use indoc::indoc;
 use liwe::model::config::{Configuration, LibraryOptions, MarkdownOptions};
-use std::env;
 use std::fs::{create_dir_all, read_to_string, write};
-use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
+
+mod common;
 
 #[test]
 fn test_normalize_basic_formatting() {
@@ -141,7 +141,7 @@ fn test_normalize_with_verbose_flag() {
     let temp_dir = setup_test_workspace_with_content();
     let temp_path = temp_dir.path();
 
-    let output = Command::new(get_iwe_binary_path())
+    let output = Command::new(common::get_iwe_binary_path())
         .arg("normalize")
         .arg("--verbose")
         .arg("1")
@@ -403,15 +403,9 @@ fn count_markdown_files(dir: &std::path::Path) -> usize {
 }
 
 fn run_normalize_command(work_dir: &std::path::Path) -> std::process::Output {
-    Command::new(get_iwe_binary_path())
+    Command::new(common::get_iwe_binary_path())
         .arg("normalize")
         .current_dir(work_dir)
         .output()
         .expect("Failed to execute iwe normalize")
-}
-
-fn get_iwe_binary_path() -> PathBuf {
-    let current_dir = env::current_dir().expect("Failed to get current directory");
-    let workspace_root = current_dir.parent().unwrap().parent().unwrap();
-    workspace_root.join("target").join("debug").join("iwe")
 }

--- a/crates/iwe/tests/paths_test.rs
+++ b/crates/iwe/tests/paths_test.rs
@@ -1,10 +1,10 @@
 use indoc::indoc;
 use liwe::model::config::{Configuration, LibraryOptions, MarkdownOptions};
-use std::env;
 use std::fs::{create_dir_all, write};
-use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
+
+mod common;
 
 #[test]
 fn test_paths_basic_output() {
@@ -172,7 +172,7 @@ fn test_paths_with_verbose_flag() {
     let temp_dir = setup_test_workspace_with_content();
     let temp_path = temp_dir.path();
 
-    let output = Command::new(get_iwe_binary_path())
+    let output = Command::new(common::get_iwe_binary_path())
         .arg("paths")
         .arg("--verbose")
         .arg("1")
@@ -428,7 +428,7 @@ fn setup_iwe_config(temp_path: &std::path::Path) {
 }
 
 fn run_paths_command(work_dir: &std::path::Path, args: &[&str]) -> std::process::Output {
-    let mut command = Command::new(get_iwe_binary_path());
+    let mut command = Command::new(common::get_iwe_binary_path());
     command.arg("paths").current_dir(work_dir);
 
     for arg in args {
@@ -436,10 +436,4 @@ fn run_paths_command(work_dir: &std::path::Path, args: &[&str]) -> std::process:
     }
 
     command.output().expect("Failed to execute iwe paths")
-}
-
-fn get_iwe_binary_path() -> PathBuf {
-    let current_dir = env::current_dir().expect("Failed to get current directory");
-    let workspace_root = current_dir.parent().unwrap().parent().unwrap();
-    workspace_root.join("target").join("debug").join("iwe")
 }

--- a/crates/iwe/tests/squash_test.rs
+++ b/crates/iwe/tests/squash_test.rs
@@ -1,10 +1,10 @@
 use indoc::indoc;
 use liwe::model::config::{Configuration, LibraryOptions, MarkdownOptions};
-use std::env;
 use std::fs::{create_dir_all, write};
-use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
+
+mod common;
 
 #[test]
 fn test_squash_basic_functionality() {
@@ -149,7 +149,7 @@ fn test_squash_with_verbose_flag() {
     let temp_dir = setup_test_workspace_with_content();
     let temp_path = temp_dir.path();
 
-    let output = Command::new(get_iwe_binary_path())
+    let output = Command::new(common::get_iwe_binary_path())
         .arg("squash")
         .arg("--key")
         .arg("test")
@@ -502,7 +502,7 @@ fn setup_iwe_config(temp_path: &std::path::Path) {
 }
 
 fn run_squash_command(work_dir: &std::path::Path, args: &[&str]) -> std::process::Output {
-    let mut command = Command::new(get_iwe_binary_path());
+    let mut command = Command::new(common::get_iwe_binary_path());
     command.arg("squash").current_dir(work_dir);
 
     for arg in args {
@@ -510,10 +510,4 @@ fn run_squash_command(work_dir: &std::path::Path, args: &[&str]) -> std::process
     }
 
     command.output().expect("Failed to execute iwe squash")
-}
-
-fn get_iwe_binary_path() -> PathBuf {
-    let current_dir = env::current_dir().expect("Failed to get current directory");
-    let workspace_root = current_dir.parent().unwrap().parent().unwrap();
-    workspace_root.join("target").join("debug").join("iwe")
 }

--- a/crates/iwe/tests/stats_test.rs
+++ b/crates/iwe/tests/stats_test.rs
@@ -1,10 +1,10 @@
 use indoc::indoc;
 use liwe::model::config::{Configuration, LibraryOptions, MarkdownOptions};
-use std::env;
 use std::fs::{create_dir_all, write};
-use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
+
+mod common;
 
 #[test]
 fn test_stats_markdown_output() {
@@ -238,7 +238,7 @@ fn setup_test_workspace_with_elements() -> TempDir {
 }
 
 fn run_stats_command(temp_dir: &TempDir, args: &[&str]) -> std::process::Output {
-    let binary_path = get_binary_path();
+    let binary_path = common::get_iwe_binary_path();
 
     let mut cmd = Command::new(binary_path);
     cmd.current_dir(temp_dir.path()).arg("stats");
@@ -248,27 +248,4 @@ fn run_stats_command(temp_dir: &TempDir, args: &[&str]) -> std::process::Output 
     }
 
     cmd.output().expect("Failed to execute stats command")
-}
-
-fn get_binary_path() -> PathBuf {
-    let mut binary_path = env::current_dir().expect("Failed to get current directory");
-
-    while !binary_path.join("Cargo.toml").exists() || !binary_path.join("crates").exists() {
-        if !binary_path.pop() {
-            panic!("Could not find workspace root");
-        }
-    }
-
-    binary_path.push("target");
-
-    let debug_path = binary_path.join("debug").join("iwe");
-    let release_path = binary_path.join("release").join("iwe");
-
-    if debug_path.exists() {
-        debug_path
-    } else if release_path.exists() {
-        release_path
-    } else {
-        panic!("Could not find iwe binary. Run 'cargo build' first.");
-    }
 }


### PR DESCRIPTION
Fix cli tests to work with release target (without debug build):

```
cargo test --profile release
```

Basically, I did it for the functionality of nix build.

Another mini refactoring in the form of removing duplicate `get_iwe_binary_path` (there were 2 variants)