### PR TITLE
feat: Add --in structural set selector across read commands

### DIFF
--- a/crates/iwe/help/attach/about.txt
+++ b/crates/iwe/help/attach/about.txt
@@ -1,0 +1,1 @@
+Attach a document as a block reference via configured attach actions

--- a/crates/iwe/help/attach/after_help.txt
+++ b/crates/iwe/help/attach/after_help.txt
@@ -1,0 +1,22 @@
+CONFIGURATION:
+
+  Define an attach action in `.iwe/config.toml`:
+
+    [actions.today]
+    type = "attach"
+    title = "{{today}}"
+    key_template = "daily/{{today}}"
+
+EXAMPLES:
+
+  # Discover available attach actions
+  iwe attach --list
+
+  # Attach a document under one configured target
+  iwe attach --to today -k meetings/standup
+
+  # Attach the same document under multiple targets at once
+  iwe attach --to today --to weekly -k meetings/standup
+
+  # Preview without writing
+  iwe attach --to today --to weekly -k meetings/standup --dry-run

--- a/crates/iwe/help/attach/long_about.txt
+++ b/crates/iwe/help/attach/long_about.txt
@@ -1,0 +1,14 @@
+Attach a source document as a block reference under one or more configured
+attach actions defined in `.iwe/config.toml`.
+
+For each --to <NAME>:
+1. Look up <NAME> in [actions]; the action must be of type `attach`.
+2. Render the action's key_template to compute the target key
+   (e.g. `daily/{{today}}` becomes `daily/2026-04-25`).
+3. If the target document doesn't exist yet, create it with the action's
+   `title` as the H1 and the new block reference as the body.
+4. If the target exists, append the new block reference.
+5. If the source is already attached in the target, that target is silently
+   skipped — no error, no warning, no duplicate write.
+
+The reference text on the new block is the source document's title.

--- a/crates/iwe/help/export/after_help.txt
+++ b/crates/iwe/help/export/after_help.txt
@@ -20,29 +20,41 @@ DOT OUTPUT FORMAT:
       }
     }
 
+STRUCTURAL SET SELECTOR (--in family):
+
+  --in KEY[:DEPTH]      Restrict to sub-documents of EVERY listed key (AND). Repeatable.
+  --in-any KEY[:DEPTH]  Restrict to sub-documents of AT LEAST ONE listed key (OR).
+  --not-in KEY[:DEPTH]  Exclude sub-documents of any listed key (NOT).
+  --max-depth N         Default depth for entries without :DEPTH. Unbounded if omitted.
+
 EXAMPLES:
 
   # Export entire graph
-  iwe export dot
+  iwe export
 
-  # Export specific document and connections
-  iwe export dot --key "project-main"
+  # Export specific document(s) and connections (-k is repeatable)
+  iwe export --key project-main
+  iwe export -k project-main -k project-beta
 
   # Include section headers for detailed view
-  iwe export dot --include-headers
+  iwe export --include-headers
 
   # Control connection depth
-  iwe export dot --key "index" --depth 2
+  iwe export --key index --depth 2
+
+  # Restrict to a subtree via the selector
+  iwe export --in projects/alpha
+  iwe export --in projects/alpha --not-in archive
 
 USING DOT OUTPUT:
 
   # Generate PNG visualization
-  iwe export dot > graph.dot
+  iwe export > graph.dot
   dot -Tpng graph.dot -o graph.png
 
   # Generate SVG for web use
-  iwe export dot --include-headers > detailed.dot
+  iwe export --include-headers > detailed.dot
   dot -Tsvg detailed.dot -o detailed.svg
 
   # Interactive exploration with xdot
-  iwe export dot | xdot -
+  iwe export | xdot -

--- a/crates/iwe/help/export/long_about.txt
+++ b/crates/iwe/help/export/long_about.txt
@@ -3,5 +3,7 @@ Export graph structure in various formats for visualization and analysis.
 Available formats:
 - dot: Graphviz DOT format for graph visualization
 
-Supports filtering by specific document key and controlling export depth.
-Use --include-headers for detailed visualization with section subgraphs.
+Filter scope with -k/--key (repeatable) or with the structural set selector
+(--in / --in-any / --not-in / --max-depth). Use --include-headers for detailed
+visualization with section subgraphs. Combining -k with the selector intersects
+the two — only explicit keys that match the selector are exported.

--- a/crates/iwe/help/find/after_help.txt
+++ b/crates/iwe/help/find/after_help.txt
@@ -26,3 +26,25 @@ JSON (-f json):
     {"query": "...", "total": 3, "results": [
       {"key": "...", "title": "...", "is_root": true,
        "incoming_refs": 5, "outgoing_refs": 2, "parent_documents": [...]}]}
+
+STRUCTURAL SET SELECTOR (--in family):
+
+  --in KEY[:DEPTH]      Sub-documents of EVERY listed key (AND). Repeatable.
+                        KEY:DEPTH overrides --max-depth per entry.
+  --in-any KEY[:DEPTH]  Sub-documents of AT LEAST ONE listed key (OR).
+  --not-in KEY[:DEPTH]  Exclude sub-documents of any listed key (NOT).
+  --max-depth N         Default depth for entries without :DEPTH. Unbounded if omitted.
+
+EXAMPLES:
+
+  # Sub-documents of A AND B (intersection, unbounded)
+  iwe find --in projects/alpha --in people/dmytro
+
+  # Per-parent depth: A within 3 hops, Dmytro within 1
+  iwe find --in projects/alpha:3 --in people/dmytro:1
+
+  # Sub-documents of A OR B (union)
+  iwe find --in-any projects/alpha --in-any projects/beta
+
+  # Sub-documents of A but NOT in archive
+  iwe find --in projects/alpha --not-in archive

--- a/crates/iwe/help/find/long_about.txt
+++ b/crates/iwe/help/find/long_about.txt
@@ -2,4 +2,5 @@ Search and discover documents in your knowledge base.
 
 Uses fuzzy matching on document title and key. Without a query, documents are
 sorted by popularity (incoming references count). Supports filtering by root
-documents or reference relationships.
+documents, reference relationships, and structural sub-document membership
+via the --in / --in-any / --not-in / --max-depth selector.

--- a/crates/iwe/help/retrieve/after_help.txt
+++ b/crates/iwe/help/retrieve/after_help.txt
@@ -44,3 +44,22 @@ JSON (-f json):
     {"documents": [{"key": "...", "title": "...",
       "content": "...", "parent_documents": [...],
       "child_documents": [...], "backlinks": [...]}]}
+
+STRUCTURAL SET SELECTOR (--in family):
+
+  --in KEY[:DEPTH]      Restrict to sub-documents of EVERY listed key (AND).
+                        Repeatable. KEY:DEPTH overrides --max-depth per entry.
+  --in-any KEY[:DEPTH]  Restrict to sub-documents of AT LEAST ONE listed key (OR).
+  --not-in KEY[:DEPTH]  Exclude sub-documents of any listed key (NOT).
+  --max-depth N         Default depth for entries without :DEPTH. Unbounded if omitted.
+
+EXAMPLES:
+
+  # Retrieve all sub-documents of A AND B (intersection)
+  iwe retrieve --in projects/alpha --in people/dmytro --depth 0
+
+  # Read explicit keys but only those inside projects/alpha's subtree
+  iwe retrieve -k x -k y -k z --in projects/alpha
+
+  # Sub-documents of A within 2 hops, excluding archive
+  iwe retrieve --in projects/alpha:2 --not-in archive

--- a/crates/iwe/help/retrieve/long_about.txt
+++ b/crates/iwe/help/retrieve/long_about.txt
@@ -6,3 +6,8 @@ Documents are collected in order:
 3. Parent context (-c N levels up)
 4. Parents of sub-documents (when -d > 0 and -c > 0)
 5. Inline linked documents (-l)
+
+Without -k, --in, or stdin, the command exits with an error. When --in / --in-any /
+--not-in / --max-depth are provided, the selector resolves to a set of keys to retrieve.
+Combining -k with the selector intersects the two — explicit keys filtered through the
+selector. Empty intersection produces an empty result.

--- a/crates/iwe/help/stats/after_help.txt
+++ b/crates/iwe/help/stats/after_help.txt
@@ -11,6 +11,13 @@ CSV (-f csv):
   outgoing_inline_refs, total_connections, bullet_lists, ordered_lists,
   code_blocks, tables, quotes
 
+JSON (-f json):
+  Aggregate graph statistics serialized as JSON. Ignored when -k is given —
+  per-document stats are always emitted as JSON regardless of -f.
+
+PER-DOCUMENT STATS (-k <KEY>):
+  Returns the JSON record for a single document. Useful for scripting.
+
 EXAMPLES:
 
   # Generate human-readable statistics
@@ -18,6 +25,12 @@ EXAMPLES:
 
   # Export per-document statistics as CSV
   iwe stats --format csv > stats.csv
+
+  # Aggregate stats as JSON
+  iwe stats -f json
+
+  # Per-document stats (always JSON)
+  iwe stats -k my-document
 
   # Find most connected documents
   iwe stats -f csv | tail -n +2 | sort -t, -k12 -nr | head -5

--- a/crates/iwe/help/stats/long_about.txt
+++ b/crates/iwe/help/stats/long_about.txt
@@ -1,5 +1,8 @@
 Generate comprehensive statistics about your knowledge graph.
 
+By default, returns aggregate stats across the whole graph. Use -k/--key to
+restrict output to a single document (always JSON).
+
 Provides analytics including:
 - Overview: document count, node count, path count
 - Document stats: sections, paragraphs, top documents

--- a/crates/iwe/help/tree/after_help.txt
+++ b/crates/iwe/help/tree/after_help.txt
@@ -1,10 +1,19 @@
 Examples:
-  iwe tree                     Show full tree with markdown links
-  iwe tree -f keys             Show tree with document keys only
-  iwe tree -f json             Show tree as JSON
-  iwe tree -k my-doc           Show tree starting from 'my-doc'
-  iwe tree -k doc-a -k doc-b   Show trees from multiple starting points
-  iwe tree --depth 2           Show only 2 levels deep
+  iwe tree                           Show full tree with markdown links
+  iwe tree -f keys                   Show tree with document keys only
+  iwe tree -f json                   Show tree as JSON
+  iwe tree -k my-doc                 Show tree starting from 'my-doc'
+  iwe tree -k doc-a -k doc-b         Show trees from multiple starting points
+  iwe tree --depth 2                 Show only 2 levels deep
+  iwe tree --in projects/alpha       Tree rooted at sub-documents of projects/alpha
+  iwe tree --in-any a --in-any b     Tree rooted at union of two subtrees
+  iwe tree --in a --not-in archive   Sub-documents of a, excluding archive
+
+Structural set selector (--in family):
+  --in KEY[:DEPTH]      Sub-documents of EVERY listed key (AND). Repeatable.
+  --in-any KEY[:DEPTH]  Sub-documents of AT LEAST ONE listed key (OR).
+  --not-in KEY[:DEPTH]  Exclude sub-documents of any listed key (NOT).
+  --max-depth N         Default depth for entries without :DEPTH. Unbounded if omitted.
 
 When documents form circular references (A→B→C→A), they have no natural root.
 Use -k to start from any document in the cycle:

--- a/crates/iwe/help/tree/long_about.txt
+++ b/crates/iwe/help/tree/long_about.txt
@@ -8,6 +8,10 @@ Use -k/--key to start the tree from specific document(s), regardless of whether
 they are roots. This is useful for viewing subtrees or documents involved in
 circular references that have no natural root.
 
+When --in / --in-any / --not-in is provided, the selector resolves to a set of
+keys and those keys are used as the tree roots. Combining -k with the selector
+intersects the two — empty intersection yields an empty tree.
+
 Output formats:
   markdown  Nested list with links (default): - [Title](key)
   keys      Document keys only

--- a/crates/iwe/help/update/about.txt
+++ b/crates/iwe/help/update/about.txt
@@ -1,0 +1,1 @@
+Overwrite a document's full markdown content

--- a/crates/iwe/help/update/after_help.txt
+++ b/crates/iwe/help/update/after_help.txt
@@ -1,0 +1,16 @@
+EXAMPLES:
+
+  # Replace a document with a fixed string
+  iwe update -k notes/draft -c "# Draft\n\nNew content."
+
+  # Pipe content from another command
+  cat new-content.md | iwe update -k notes/draft -c -
+
+  # Preview without writing
+  iwe update -k notes/draft -c "..." --dry-run
+
+NOTES:
+
+  - The target document must already exist; update does not create new docs.
+  - Use `iwe new` to create documents from a template.
+  - Use `iwe attach` to append a block reference instead of overwriting.

--- a/crates/iwe/help/update/long_about.txt
+++ b/crates/iwe/help/update/long_about.txt
@@ -1,0 +1,7 @@
+Overwrite the full markdown content of an existing document.
+
+The document at -k/--key is rewritten with -c/--content. Use '-' as the value of
+--content to read from stdin instead of passing inline.
+
+The graph is not mutated by update itself; the file change is picked up on the
+next read. Run `iwe normalize` afterward if you want to canonicalize the output.

--- a/crates/iwe/src/export/graph_data.rs
+++ b/crates/iwe/src/export/graph_data.rs
@@ -50,12 +50,12 @@ struct GraphCache {
     backlinks: HashSet<(Key, Key)>,
 }
 
-pub fn graph_data(key_filter: Option<Key>, depth: u8, graph: &Graph) -> GraphData {
-    let keys = filter_keys(graph, key_filter.clone(), depth);
+pub fn graph_data(key_filter: Vec<Key>, depth: u8, graph: &Graph) -> GraphData {
+    let keys = filter_keys(graph, key_filter, depth);
 
     keys.iter()
         .map(|pair| {
-            
+
             build_graph_data(graph, pair.0, *pair.1)
         })
         .fold(
@@ -155,11 +155,18 @@ fn build_sections(
     })
 }
 
-fn filter_keys(graph: &Graph, key_filter: Option<Key>, depth_limit: u8) -> HashMap<Key, u8> {
-    key_filter
-        .clone()
-        .map(|key| filter_key(graph, key, depth_limit))
-        .unwrap_or_else(|| top_level_keys(graph, depth_limit))
+fn filter_keys(graph: &Graph, key_filter: Vec<Key>, depth_limit: u8) -> HashMap<Key, u8> {
+    if key_filter.is_empty() {
+        top_level_keys(graph, depth_limit)
+    } else {
+        let mut result = HashMap::new();
+        for key in key_filter {
+            for (k, d) in filter_key(graph, key, depth_limit) {
+                result.entry(k).or_insert(d);
+            }
+        }
+        result
+    }
 }
 
 fn top_level_keys(graph: &Graph, depth_limit: u8) -> HashMap<Key, u8> {

--- a/crates/iwe/src/help.rs
+++ b/crates/iwe/src/help.rs
@@ -75,3 +75,15 @@ pub mod inline {
     pub const LONG_ABOUT: &str = include_str!("../help/inline/long_about.txt");
     pub const AFTER_HELP: &str = include_str!("../help/inline/after_help.txt");
 }
+
+pub mod update {
+    pub const ABOUT: &str = include_str!("../help/update/about.txt");
+    pub const LONG_ABOUT: &str = include_str!("../help/update/long_about.txt");
+    pub const AFTER_HELP: &str = include_str!("../help/update/after_help.txt");
+}
+
+pub mod attach {
+    pub const ABOUT: &str = include_str!("../help/attach/about.txt");
+    pub const LONG_ABOUT: &str = include_str!("../help/attach/long_about.txt");
+    pub const AFTER_HELP: &str = include_str!("../help/attach/after_help.txt");
+}

--- a/crates/iwe/src/lib.rs
+++ b/crates/iwe/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod export;
 pub mod new;
 pub mod render;
+pub mod selector;
 pub mod stats;
 
 pub use liwe::find;

--- a/crates/iwe/src/main.rs
+++ b/crates/iwe/src/main.rs
@@ -13,6 +13,7 @@ use iwe::find::{DocumentFinder, FindOptions};
 use iwe::new::{read_stdin_if_available, CreateOptions, DocumentCreator, IfExists};
 use iwe::render::RetrieveRenderer;
 use iwe::retrieve::{DocumentReader, RetrieveOptions};
+use iwe::selector::SelectorArgs;
 use iwe::stats::{render_stats, GraphStatistics};
 use liwe::fs::new_for_path;
 use liwe::graph::{Graph, GraphContext};
@@ -59,6 +60,8 @@ enum Command {
     Delete(Delete),
     Extract(Extract),
     Inline(Inline),
+    Update(Update),
+    Attach(Attach),
 }
 
 #[derive(Debug, Args)]
@@ -104,6 +107,9 @@ struct Retrieve {
 
     #[clap(long, help = "Exclude document content from results (metadata only)")]
     no_content: bool,
+
+    #[clap(flatten)]
+    selector: SelectorArgs,
 }
 
 #[derive(Debug, Clone, clap::ValueEnum)]
@@ -143,6 +149,9 @@ struct Find {
 
     #[clap(long, short = 'f', value_enum, default_value = "markdown")]
     format: FindFormat,
+
+    #[clap(flatten)]
+    selector: SelectorArgs,
 }
 
 #[derive(Debug, Clone, clap::ValueEnum)]
@@ -227,6 +236,9 @@ struct TreeArgs {
         help = "Maximum depth to traverse"
     )]
     depth: u8,
+
+    #[clap(flatten)]
+    selector: SelectorArgs,
 }
 
 #[derive(Debug, Clone, clap::ValueEnum)]
@@ -259,12 +271,20 @@ struct Stats {
         help = "Output format for statistics"
     )]
     format: StatsFormat,
+
+    #[clap(
+        long,
+        short = 'k',
+        help = "Document key for per-document stats. Omit for aggregate graph statistics."
+    )]
+    key: Option<String>,
 }
 
 #[derive(Debug, Clone, clap::ValueEnum)]
 enum StatsFormat {
     Markdown,
     Csv,
+    Json,
 }
 
 #[derive(Debug, Args)]
@@ -274,13 +294,20 @@ enum StatsFormat {
     after_help = help::export::AFTER_HELP
 )]
 struct Export {
+    #[clap(
+        long,
+        short = 'f',
+        value_enum,
+        default_value = "dot",
+        help = "Output format"
+    )]
     format: Format,
     #[clap(
         long,
         short = 'k',
-        help = "Filter nodes by specific key. If not provided, exports all root notes by default"
+        help = "Filter nodes by document key. Repeatable; if omitted, exports all root notes."
     )]
-    key: Option<String>,
+    key: Vec<String>,
     #[clap(
         long,
         short = 'd',
@@ -297,6 +324,9 @@ struct Export {
         help = "Include section headers and create subgraphs for detailed visualization. When enabled, shows document structure with sections grouped in colored subgraphs"
     )]
     include_headers: bool,
+
+    #[clap(flatten)]
+    selector: SelectorArgs,
 }
 
 #[derive(Debug, Clone, clap::ValueEnum)]
@@ -403,6 +433,48 @@ struct Extract {
 }
 
 #[derive(Debug, Args)]
+#[clap(about = "Overwrite a document's full markdown content")]
+struct Update {
+    #[clap(long, short = 'k', help = "Document key to update")]
+    key: String,
+
+    #[clap(
+        long,
+        short = 'c',
+        help = "New full markdown content. Use '-' to read from stdin."
+    )]
+    content: String,
+
+    #[clap(long, help = "Preview without writing")]
+    dry_run: bool,
+
+    #[clap(long, help = "Suppress progress output")]
+    quiet: bool,
+}
+
+#[derive(Debug, Args)]
+#[clap(about = "Attach a document as a block reference via one or more configured attach actions")]
+struct Attach {
+    #[clap(
+        long,
+        help = "Configured attach action(s) to attach to. Repeatable for multiple targets."
+    )]
+    to: Vec<String>,
+
+    #[clap(long, short = 'k', help = "Source document key to attach")]
+    key: Option<String>,
+
+    #[clap(long, help = "List configured attach actions")]
+    list: bool,
+
+    #[clap(long, help = "Preview without writing")]
+    dry_run: bool,
+
+    #[clap(long, help = "Suppress progress output")]
+    quiet: bool,
+}
+
+#[derive(Debug, Args)]
 #[clap(
     about = help::inline::ABOUT,
     long_about = help::inline::LONG_ABOUT,
@@ -477,6 +549,8 @@ fn main() {
         Command::Delete(delete) => delete_command(delete),
         Command::Extract(extract) => extract_command(extract),
         Command::Inline(inline) => inline_command(inline),
+        Command::Update(update) => update_command(update),
+        Command::Attach(attach) => attach_command(attach),
     }
 }
 
@@ -485,6 +559,12 @@ fn retrieve_command(args: Retrieve) {
     let config = get_configuration();
     let graph = load_graph(&config);
 
+    let selector_args = args.selector.clone();
+    let selector_provided = !selector_args.in_.is_empty()
+        || !selector_args.in_any.is_empty()
+        || !selector_args.not_in.is_empty()
+        || selector_args.max_depth.is_some();
+
     let key_strings: Vec<String> = if args.key.is_empty() {
         let stdin_content = read_stdin_if_available();
         let keys: Vec<String> = stdin_content
@@ -492,8 +572,8 @@ fn retrieve_command(args: Retrieve) {
             .map(|s| s.trim().to_string())
             .filter(|s| !s.is_empty())
             .collect();
-        if keys.is_empty() {
-            eprintln!("Error: No document key provided. Use -k <key> or pipe keys via stdin.");
+        if keys.is_empty() && !selector_provided {
+            eprintln!("Error: No document key provided. Use -k <key>, --in <key>, or pipe keys via stdin.");
             std::process::exit(1);
         }
         keys
@@ -524,6 +604,7 @@ fn retrieve_command(args: Retrieve) {
         backlinks: args.backlinks,
         exclude,
         no_content: args.no_content,
+        selector: args.selector.into(),
     };
 
     let output = reader.retrieve_many(&keys, &options);
@@ -569,6 +650,7 @@ fn find_command(args: Find) {
         roots: args.roots,
         refs_to: args.refs_to.map(|s| Key::name(&s)),
         refs_from: args.refs_from.map(|s| Key::name(&s)),
+        selector: args.selector.into(),
         limit: args.limit,
     };
 
@@ -691,7 +773,23 @@ fn tree_command(args: TreeArgs) {
     let config = get_configuration();
     let graph = load_graph(&config);
 
-    let root_keys: Vec<Key> = if args.key.is_empty() {
+    let selector: liwe::selector::Selector = args.selector.into();
+
+    let explicit_keys: Vec<Key> = args.key.iter().map(|k| Key::name(k)).collect();
+
+    let root_keys: Vec<Key> = if !selector.is_empty() {
+        let selector_set = selector.resolve(&graph);
+        if explicit_keys.is_empty() {
+            let mut v: Vec<Key> = selector_set.into_iter().collect();
+            v.sort();
+            v
+        } else {
+            explicit_keys
+                .into_iter()
+                .filter(|k| selector_set.contains(k))
+                .collect()
+        }
+    } else if explicit_keys.is_empty() {
         let paths = graph.paths();
         paths
             .iter()
@@ -702,7 +800,7 @@ fn tree_command(args: TreeArgs) {
             .unique()
             .collect()
     } else {
-        args.key.iter().map(|k| Key::name(k)).collect()
+        explicit_keys
     };
 
     for root_key in &root_keys {
@@ -940,6 +1038,25 @@ fn stats_command(args: Stats) {
     let config = get_configuration();
     let graph = load_graph(&config);
 
+    if let Some(key_str) = args.key {
+        let key_stats = liwe::stats::KeyStatistics::from_graph(&graph);
+        let entry = key_stats
+            .into_iter()
+            .find(|s| s.key == key_str);
+        match entry {
+            Some(s) => {
+                let json = serde_json::to_string_pretty(&s)
+                    .expect("Failed to serialize stats");
+                println!("{}", json);
+            }
+            None => {
+                eprintln!("Error: Document '{}' not found", key_str);
+                std::process::exit(1);
+            }
+        }
+        return;
+    }
+
     match args.format {
         StatsFormat::Markdown => {
             let stats = GraphStatistics::from_graph(&graph);
@@ -953,6 +1070,12 @@ fn stats_command(args: Stats) {
                 std::process::exit(1);
             }
         }
+        StatsFormat::Json => {
+            let stats = GraphStatistics::from_graph(&graph);
+            let json = serde_json::to_string_pretty(&stats)
+                .expect("Failed to serialize stats");
+            println!("{}", json);
+        }
     }
 }
 
@@ -960,11 +1083,27 @@ fn stats_command(args: Stats) {
 fn export_command(args: Export) {
     let config = get_configuration();
     let graph = load_graph(&config);
-    let data = graph_data::graph_data(
-        args.key.clone().map(|s| Key::name(&s)).clone(),
-        args.depth,
-        &graph,
-    );
+
+    let explicit_keys: Vec<Key> = args.key.iter().map(|s| Key::name(s)).collect();
+
+    let selector: liwe::selector::Selector = args.selector.into();
+    let resolved_keys: Vec<Key> = if !selector.is_empty() {
+        let selector_set = selector.resolve(&graph);
+        let mut v: Vec<Key> = if explicit_keys.is_empty() {
+            selector_set.into_iter().collect()
+        } else {
+            explicit_keys
+                .into_iter()
+                .filter(|k| selector_set.contains(k))
+                .collect()
+        };
+        v.sort();
+        v
+    } else {
+        explicit_keys
+    };
+
+    let data = graph_data::graph_data(resolved_keys, args.depth, &graph);
 
     let output = match args.format {
         Format::Dot => {
@@ -1397,4 +1536,177 @@ fn inline_command(args: Inline) {
             println!("Done");
         }
     }
+}
+
+#[tracing::instrument(level = "debug")]
+fn update_command(args: Update) {
+    let config = get_configuration();
+    let graph = load_graph(&config);
+
+    let key = Key::name(&args.key);
+    if (&graph).get_node_id(&key).is_none() {
+        eprintln!("Error: Document '{}' not found", args.key);
+        std::process::exit(1);
+    }
+
+    let content = if args.content == "-" {
+        let stdin_content = read_stdin_if_available();
+        if stdin_content.is_empty() {
+            eprintln!("Error: '--content -' requires content piped via stdin");
+            std::process::exit(1);
+        }
+        stdin_content
+    } else {
+        args.content
+    };
+
+    if args.dry_run {
+        if !args.quiet {
+            println!("Would update '{}' ({} bytes)", args.key, content.len());
+        }
+        return;
+    }
+
+    let library_path = get_library_path(&config);
+    let file_path = library_path.join(format!("{}.md", key));
+    if let Some(parent) = file_path.parent() {
+        std::fs::create_dir_all(parent).ok();
+    }
+    std::fs::write(&file_path, &content).expect("Failed to write document file");
+
+    if !args.quiet {
+        println!("Updated '{}'", args.key);
+    }
+}
+
+#[tracing::instrument(level = "debug")]
+fn attach_command(args: Attach) {
+    let config = get_configuration();
+
+    if args.list {
+        for (name, action) in &config.actions {
+            if let ActionDefinition::Attach(a) = action {
+                let target = render_key_template(&a.key_template);
+                println!("{}\t{}\t{}", name, a.title, target);
+            }
+        }
+        return;
+    }
+
+    if args.to.is_empty() {
+        eprintln!("Error: --to <ACTION> is required when not in --list mode (repeatable)");
+        std::process::exit(1);
+    }
+    let source_key_str = args.key.clone().unwrap_or_else(|| {
+        eprintln!("Error: --key is required when not in --list mode");
+        std::process::exit(1)
+    });
+    let source_key = Key::name(&source_key_str);
+
+    let graph = load_graph(&config);
+    if (&graph).get_node_id(&source_key).is_none() {
+        eprintln!("Error: Source document '{}' not found", source_key_str);
+        std::process::exit(1);
+    }
+
+    let reference_text = (&graph)
+        .get_key_title(&source_key)
+        .unwrap_or_else(|| source_key_str.clone());
+
+    let library_path = get_library_path(&config);
+
+    for action_name in &args.to {
+        let attach = match config.actions.get(action_name) {
+            Some(ActionDefinition::Attach(a)) => a.clone(),
+            Some(_) => {
+                eprintln!("Error: Action '{}' is not an attach action", action_name);
+                std::process::exit(1);
+            }
+            None => {
+                eprintln!("Error: Action '{}' not found", action_name);
+                std::process::exit(1);
+            }
+        };
+
+        let target_key_str = render_key_template(&attach.key_template);
+        let target_key = Key::name(&target_key_str);
+
+        if (&graph).get_node_id(&target_key).is_some() {
+            let tree = (&graph).collect(&target_key);
+            if tree.get_all_block_reference_keys().contains(&source_key) {
+                continue;
+            }
+        }
+
+        if args.dry_run {
+            if !args.quiet {
+                println!(
+                    "Would attach '{}' to '{}' as [{}]({})",
+                    source_key_str, target_key, reference_text, source_key_str
+                );
+            }
+            continue;
+        }
+
+        let target_path = library_path.join(format!("{}.md", target_key));
+        let line = format!("[{}]({})\n", reference_text, source_key);
+
+        if let Some(parent) = target_path.parent() {
+            std::fs::create_dir_all(parent).ok();
+        }
+
+        if target_path.exists() {
+            let mut existing = std::fs::read_to_string(&target_path)
+                .expect("Failed to read existing target file");
+            if !existing.ends_with('\n') {
+                existing.push('\n');
+            }
+            existing.push('\n');
+            existing.push_str(&line);
+            std::fs::write(&target_path, existing).expect("Failed to write target file");
+        } else {
+            let title = render_attach_title(&attach.title);
+            let initial = format!("# {}\n\n{}", title, line);
+            std::fs::write(&target_path, initial).expect("Failed to write target file");
+        }
+
+        if !args.quiet {
+            println!(
+                "Attached '{}' to '{}' as [{}]",
+                source_key_str, target_key, reference_text
+            );
+        }
+    }
+}
+
+fn render_key_template(template: &str) -> String {
+    use chrono::Local;
+    use minijinja::{context, Environment};
+    let now = Local::now();
+    let formatted = now.format("%Y-%m-%d").to_string();
+    Environment::new()
+        .template_from_str(template)
+        .expect("valid key template")
+        .render(context! {
+            today => &formatted,
+            now => &formatted,
+        })
+        .expect("key template to render")
+}
+
+fn render_attach_title(template: &str) -> String {
+    use chrono::Local;
+    use minijinja::{context, Environment};
+    let now = Local::now();
+    let formatted = now.format("%Y-%m-%d").to_string();
+    Environment::new()
+        .template_from_str(template)
+        .map(|t| {
+            t.render(context! {
+                today => &formatted,
+                now => &formatted,
+            })
+            .unwrap_or_else(|_| template.to_string())
+        })
+        .unwrap_or_else(|_| template.to_string())
 }

--- a/crates/iwe/src/main.rs
+++ b/crates/iwe/src/main.rs
@@ -433,7 +433,11 @@ struct Extract {
 }
 
 #[derive(Debug, Args)]
-#[clap(about = "Overwrite a document's full markdown content")]
+#[clap(
+    about = help::update::ABOUT,
+    long_about = help::update::LONG_ABOUT,
+    after_help = help::update::AFTER_HELP
+)]
 struct Update {
     #[clap(long, short = 'k', help = "Document key to update")]
     key: String,
@@ -453,7 +457,11 @@ struct Update {
 }
 
 #[derive(Debug, Args)]
-#[clap(about = "Attach a document as a block reference via one or more configured attach actions")]
+#[clap(
+    about = help::attach::ABOUT,
+    long_about = help::attach::LONG_ABOUT,
+    after_help = help::attach::AFTER_HELP
+)]
 struct Attach {
     #[clap(
         long,

--- a/crates/iwe/src/selector.rs
+++ b/crates/iwe/src/selector.rs
@@ -1,0 +1,56 @@
+use clap::Args;
+
+use liwe::model::Key;
+use liwe::selector::{KeyDepth, Selector};
+
+#[derive(Debug, Args, Clone, Default)]
+pub struct SelectorArgs {
+    #[clap(
+        long = "in",
+        value_parser = parse_key_depth,
+        help = "Restrict to sub-documents of EVERY listed key (AND). Use KEY or KEY:DEPTH. Repeat for multiple."
+    )]
+    pub in_: Vec<KeyDepth>,
+
+    #[clap(
+        long = "in-any",
+        value_parser = parse_key_depth,
+        help = "Restrict to sub-documents of AT LEAST ONE listed key (OR). Use KEY or KEY:DEPTH."
+    )]
+    pub in_any: Vec<KeyDepth>,
+
+    #[clap(
+        long = "not-in",
+        value_parser = parse_key_depth,
+        help = "Exclude sub-documents of any listed key (NOT). Use KEY or KEY:DEPTH."
+    )]
+    pub not_in: Vec<KeyDepth>,
+
+    #[clap(
+        long = "max-depth",
+        help = "Default depth applied to in / in-any / not-in entries without their own depth. Omit for unbounded."
+    )]
+    pub max_depth: Option<u8>,
+}
+
+impl From<SelectorArgs> for Selector {
+    fn from(args: SelectorArgs) -> Self {
+        Selector {
+            in_: args.in_,
+            in_any: args.in_any,
+            not_in: args.not_in,
+            max_depth: args.max_depth,
+        }
+    }
+}
+
+fn parse_key_depth(s: &str) -> Result<KeyDepth, String> {
+    if let Some((k, d)) = s.rsplit_once(':') {
+        let depth: u8 = d
+            .parse()
+            .map_err(|_| format!("invalid depth in '{}': expected non-negative integer", s))?;
+        Ok(KeyDepth::with_depth(Key::name(k), depth))
+    } else {
+        Ok(KeyDepth::bare(Key::name(s)))
+    }
+}

--- a/crates/iwe/tests/export_dot_test.rs
+++ b/crates/iwe/tests/export_dot_test.rs
@@ -85,7 +85,10 @@ fn run_export_dot_command(temp_dir: &TempDir, args: &[&str]) -> std::process::Ou
     let binary_path = common::get_iwe_binary_path();
 
     let mut cmd = Command::new(binary_path);
-    cmd.current_dir(temp_dir.path()).arg("export").arg("dot");
+    cmd.current_dir(temp_dir.path())
+        .arg("export")
+        .arg("-f")
+        .arg("dot");
 
     for arg in args {
         cmd.arg(arg);

--- a/crates/iwec/src/lib.rs
+++ b/crates/iwec/src/lib.rs
@@ -7,6 +7,7 @@ use std::sync::Arc;
 
 use liwe::find::{DocumentFinder, FindOptions, FindOutput};
 use liwe::retrieve::{DocumentReader, RetrieveOptions, RetrieveOutput};
+use liwe::selector::{KeyDepth, Selector};
 use liwe::stats::{GraphStatistics, KeyStatistics};
 use liwe::fs::{new_for_path, new_from_hashmap};
 use liwe::graph::{Graph, GraphContext};
@@ -42,6 +43,63 @@ fn to_text_result(text: String) -> Result<CallToolResult, McpError> {
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
+#[serde(untagged)]
+pub enum KeyDepthParam {
+    Bare(String),
+    Qualified {
+        key: String,
+        depth: Option<u8>,
+    },
+}
+
+impl From<KeyDepthParam> for KeyDepth {
+    fn from(p: KeyDepthParam) -> Self {
+        match p {
+            KeyDepthParam::Bare(s) => KeyDepth::bare(Key::name(&s)),
+            KeyDepthParam::Qualified { key, depth } => match depth {
+                Some(d) => KeyDepth::with_depth(Key::name(&key), d),
+                None => KeyDepth::bare(Key::name(&key)),
+            },
+        }
+    }
+}
+
+#[derive(Debug, Default, Deserialize, JsonSchema)]
+pub struct SelectorParams {
+    #[schemars(
+        description = "Restrict to candidates that are sub-documents of EVERY listed key (AND). Each entry is either a bare KEY or {key, depth}."
+    )]
+    #[serde(rename = "in", default)]
+    pub in_: Vec<KeyDepthParam>,
+    #[schemars(
+        description = "Restrict to candidates that are sub-documents of AT LEAST ONE listed key (OR)."
+    )]
+    #[serde(default)]
+    pub in_any: Vec<KeyDepthParam>,
+    #[schemars(
+        description = "Exclude candidates that are sub-documents of ANY listed key (NOT)."
+    )]
+    #[serde(default)]
+    pub not_in: Vec<KeyDepthParam>,
+    #[schemars(
+        description = "Default depth for in / in_any / not_in entries that don't specify their own depth. Omit for unbounded."
+    )]
+    #[serde(default)]
+    pub max_depth: Option<u8>,
+}
+
+impl From<SelectorParams> for Selector {
+    fn from(p: SelectorParams) -> Self {
+        Selector {
+            in_: p.in_.into_iter().map(Into::into).collect(),
+            in_any: p.in_any.into_iter().map(Into::into).collect(),
+            not_in: p.not_in.into_iter().map(Into::into).collect(),
+            max_depth: p.max_depth,
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, JsonSchema)]
 pub struct FindParams {
     #[schemars(description = "Fuzzy search query matching against document title and key")]
     pub query: Option<String>,
@@ -53,6 +111,8 @@ pub struct FindParams {
     pub refs_from: Option<String>,
     #[schemars(description = "Maximum number of results to return")]
     pub limit: Option<usize>,
+    #[serde(flatten)]
+    pub selector: SelectorParams,
 }
 
 impl From<FindParams> for FindOptions {
@@ -62,6 +122,7 @@ impl From<FindParams> for FindOptions {
             roots: p.roots.unwrap_or(false),
             refs_to: p.refs_to.map(|k| Key::name(&k)),
             refs_from: p.refs_from.map(|k| Key::name(&k)),
+            selector: p.selector.into(),
             limit: p.limit,
         }
     }
@@ -69,7 +130,8 @@ impl From<FindParams> for FindOptions {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct RetrieveParams {
-    #[schemars(description = "Document keys to retrieve")]
+    #[schemars(description = "Document keys to retrieve. Can be empty when a structural selector is provided.")]
+    #[serde(default)]
     pub keys: Vec<String>,
     #[schemars(description = "Levels of block references to expand (0 = document only, 1 = include direct sub-documents). Default: 1")]
     pub depth: Option<u8>,
@@ -83,6 +145,8 @@ pub struct RetrieveParams {
     pub exclude: Option<Vec<String>>,
     #[schemars(description = "Return metadata only without document content. Default: false")]
     pub no_content: Option<bool>,
+    #[serde(flatten)]
+    pub selector: SelectorParams,
 }
 
 impl From<RetrieveParams> for RetrieveOptions {
@@ -99,16 +163,19 @@ impl From<RetrieveParams> for RetrieveOptions {
                 .map(|k| Key::name(&k))
                 .collect::<HashSet<_>>(),
             no_content: p.no_content.unwrap_or(false),
+            selector: p.selector.into(),
         }
     }
 }
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct TreeParams {
-    #[schemars(description = "Starting document keys. If empty, shows all root documents")]
+    #[schemars(description = "Starting document keys. If empty and no selector, shows all root documents.")]
     pub keys: Option<Vec<String>>,
     #[schemars(description = "Maximum traversal depth. Default: 4")]
     pub depth: Option<u8>,
+    #[serde(flatten)]
+    pub selector: SelectorParams,
 }
 
 #[derive(Debug, Serialize)]
@@ -237,12 +304,11 @@ struct ReferenceEntry {
 
 #[derive(Debug, Deserialize, JsonSchema)]
 pub struct AttachParams {
-    #[schemars(description = "Name of the configured attach action (e.g. 'today')")]
-    pub action: Option<String>,
-    #[schemars(description = "Document key to attach as a block reference in the target")]
+    #[schemars(description = "Configured attach action(s) to attach to (e.g. 'today'). Pass one or more action names; the source is attached under each resolved target.")]
+    #[serde(default)]
+    pub to: Vec<String>,
+    #[schemars(description = "Document key to attach as a block reference in the target(s)")]
     pub key: Option<String>,
-    #[schemars(description = "Custom reference text (defaults to document title)")]
-    pub text: Option<String>,
     #[schemars(description = "List available attach actions instead of executing. Default: false")]
     pub list: Option<bool>,
     #[schemars(description = "Preview changes without applying. Default: false")]
@@ -352,7 +418,7 @@ pub struct IweServer {
 
 #[tool_router]
 impl IweServer {
-    #[tool(description = "Search and discover documents in the knowledge graph by fuzzy query, structural filters, or reference relationships")]
+    #[tool(description = "Search and discover documents in the knowledge graph. Supports fuzzy text query (`query`), root filter (`roots`), direct-reference filters (`refs_to`, `refs_from`), and the structural set selector (`in` / `in_any` / `not_in` / `max_depth`) for transitive sub-document AND/OR/NOT queries with configurable depth.")]
     async fn iwe_find(
         &self,
         Parameters(params): Parameters<FindParams>,
@@ -376,14 +442,34 @@ impl IweServer {
         to_json_result(&output)
     }
 
-    #[tool(description = "View the hierarchical tree structure of the knowledge graph showing how documents are connected via block references")]
+    #[tool(description = "View the hierarchical tree structure of the knowledge graph showing how documents are connected via block references. Supports the structural set selector (in / in_any / not_in / max_depth) — when provided, the tree roots are restricted to (or selected from) that set.")]
     async fn iwe_tree(
         &self,
         Parameters(params): Parameters<TreeParams>,
     ) -> Result<CallToolResult, McpError> {
         let graph = self.graph.lock().await;
-        let root_keys: Vec<Key> = if let Some(keys) = params.keys.filter(|k| !k.is_empty()) {
-            keys.iter().map(|k| Key::name(k)).collect()
+
+        let selector: Selector = params.selector.into();
+        let explicit_keys: Vec<Key> = params
+            .keys
+            .filter(|k| !k.is_empty())
+            .map(|ks| ks.iter().map(|k| Key::name(k)).collect())
+            .unwrap_or_default();
+
+        let root_keys: Vec<Key> = if !selector.is_empty() {
+            let selector_set = selector.resolve(&graph);
+            if explicit_keys.is_empty() {
+                let mut v: Vec<Key> = selector_set.into_iter().collect();
+                v.sort();
+                v
+            } else {
+                explicit_keys
+                    .into_iter()
+                    .filter(|k| selector_set.contains(k))
+                    .collect()
+            }
+        } else if !explicit_keys.is_empty() {
+            explicit_keys
         } else {
             let paths = graph.paths();
             let mut keys: Vec<Key> = paths
@@ -764,7 +850,7 @@ impl IweServer {
         })
     }
 
-    #[tool(description = "Attach a document as a block reference in a target document determined by a configured attach action. The target key is derived from the action's key_template (e.g. daily/{{today}}). Use list mode to discover available attach actions")]
+    #[tool(description = "Attach a document as a block reference in one or more target documents determined by configured attach actions. Each target key is derived from the action's key_template (e.g. daily/{{today}}). The `to` field accepts a list of action names; the source is attached under each resolved target. Targets that already contain the source are silently skipped. Use list mode to discover available attach actions.")]
     async fn iwe_attach(
         &self,
         Parameters(params): Parameters<AttachParams>,
@@ -789,34 +875,19 @@ impl IweServer {
             return to_json_result(&entries);
         }
 
-        let action_name = params.action.as_deref().ok_or_else(|| {
-            McpError::invalid_params("'action' is required when not in list mode".to_string(), None)
-        })?;
+        if params.to.is_empty() {
+            return Err(McpError::invalid_params(
+                "'to' is required when not in list mode (pass one or more action names)".to_string(),
+                None,
+            ));
+        }
         let source_key_str = params.key.as_deref().ok_or_else(|| {
             McpError::invalid_params("'key' is required when not in list mode".to_string(), None)
         })?;
 
-        let attach = match self.config.actions.get(action_name) {
-            Some(ActionDefinition::Attach(a)) => a,
-            Some(_) => {
-                return Err(McpError::invalid_params(
-                    format!("Action '{}' is not an attach action", action_name),
-                    None,
-                ));
-            }
-            None => {
-                return Err(McpError::invalid_params(
-                    format!("Action '{}' not found", action_name),
-                    None,
-                ));
-            }
-        };
-
-        let target_key = Key::name(&self.render_key_template(&attach.key_template));
-        let source_key = Key::name(source_key_str);
-
         let mut graph = self.graph.lock().await;
 
+        let source_key = Key::name(source_key_str);
         if (&*graph).get_node_id(&source_key).is_none() {
             return Err(McpError::invalid_params(
                 format!("Document '{}' not found", source_key_str),
@@ -824,65 +895,79 @@ impl IweServer {
             ));
         }
 
-        let reference_text = params.text.unwrap_or_else(|| {
-            (&*graph)
-                .get_key_title(&source_key)
-                .unwrap_or_else(|| source_key_str.to_string())
-        });
+        let reference_text = (&*graph)
+            .get_key_title(&source_key)
+            .unwrap_or_else(|| source_key_str.to_string());
 
-        if (&*graph).get_node_id(&target_key).is_some() {
-            let tree = (&*graph).collect(&target_key);
-            if tree
-                .get_all_block_reference_keys()
-                .contains(&source_key)
-            {
-                return Err(McpError::invalid_params(
-                    format!(
-                        "Document '{}' is already attached in '{}'",
-                        source_key_str, target_key
-                    ),
-                    None,
-                ));
+        let mut combined = Changes::new();
+        let markdown_options = graph.markdown_options();
+
+        for action_name in &params.to {
+            let attach = match self.config.actions.get(action_name) {
+                Some(ActionDefinition::Attach(a)) => a,
+                Some(_) => {
+                    return Err(McpError::invalid_params(
+                        format!("Action '{}' is not an attach action", action_name),
+                        None,
+                    ));
+                }
+                None => {
+                    return Err(McpError::invalid_params(
+                        format!("Action '{}' not found", action_name),
+                        None,
+                    ));
+                }
+            };
+
+            let target_key = Key::name(&self.render_key_template(&attach.key_template));
+
+            if (&*graph).get_node_id(&target_key).is_some() {
+                let tree = (&*graph).collect(&target_key);
+                if tree
+                    .get_all_block_reference_keys()
+                    .contains(&source_key)
+                {
+                    continue;
+                }
+            }
+
+            let reference = Tree {
+                id: None,
+                node: Node::Reference(Reference {
+                    key: source_key.clone(),
+                    text: reference_text.clone(),
+                    reference_type: ReferenceType::Regular,
+                }),
+                children: vec![],
+            };
+
+            if (&*graph).get_node_id(&target_key).is_some() {
+                let tree = (&*graph).collect(&target_key);
+                let updated = tree.attach(reference);
+                combined.add_update(
+                    target_key.clone(),
+                    updated
+                        .iter()
+                        .to_markdown(&target_key.parent(), &markdown_options),
+                );
+            } else {
+                let content = reference
+                    .iter()
+                    .to_markdown(&target_key.parent(), &markdown_options);
+                let document = self.render_document_template(
+                    &attach.document_template,
+                    &content,
+                );
+                combined.add_create(target_key.clone(), document);
             }
         }
 
-        let reference = Tree {
-            id: None,
-            node: Node::Reference(Reference {
-                key: source_key,
-                text: reference_text,
-                reference_type: ReferenceType::Regular,
-            }),
-            children: vec![],
-        };
-
-        let markdown_options = graph.markdown_options();
-        let changes = if (&*graph).get_node_id(&target_key).is_some() {
-            let tree = (&*graph).collect(&target_key);
-            let updated = tree.attach(reference);
-            Changes::new().update(
-                target_key.clone(),
-                updated
-                    .iter()
-                    .to_markdown(&target_key.parent(), &markdown_options),
-            )
-        } else {
-            let content = reference
-                .iter()
-                .to_markdown(&target_key.parent(), &markdown_options);
-            let document = self.render_document_template(
-                &attach.document_template,
-                &content,
-            );
-            Changes::new().create(target_key.clone(), document)
-        };
-
         if !params.dry_run.unwrap_or(false) {
-            Self::apply_changes(&mut graph, &changes);
-            self.write_changes(&changes);
+            Self::apply_changes(&mut graph, &combined);
+            self.write_changes(&combined);
         }
 
-        to_json_result(&ChangesOutput::from(&changes))
+        to_json_result(&ChangesOutput::from(&combined))
     }
 }
 

--- a/crates/iwec/tests/attach_test.rs
+++ b/crates/iwec/tests/attach_test.rs
@@ -43,7 +43,7 @@ async fn attach_creates_new_target() {
     let result = f
         .call_tool(
             "iwe_attach",
-            serde_json::json!({"action": "today", "key": "notes"}),
+            serde_json::json!({"to": ["today"], "key": "notes"}),
         )
         .await;
     let json = fixture::Fixture::result_json(&result);
@@ -67,7 +67,7 @@ async fn attach_appends_to_existing_target() {
     let result = f
         .call_tool(
             "iwe_attach",
-            serde_json::json!({"action": "today", "key": "notes"}),
+            serde_json::json!({"to": ["today"], "key": "notes"}),
         )
         .await;
     let json = fixture::Fixture::result_json(&result);
@@ -78,7 +78,7 @@ async fn attach_appends_to_existing_target() {
 }
 
 #[tokio::test]
-async fn attach_rejects_duplicate() {
+async fn attach_silently_skips_already_attached() {
     let f = fixture::Fixture::with_documents_and_config(
         vec![
             ("notes", "# My Notes"),
@@ -89,15 +89,96 @@ async fn attach_rejects_duplicate() {
     .await;
 
     let result = f
-        .try_call_tool(
+        .call_tool(
             "iwe_attach",
-            serde_json::json!({"action": "today", "key": "notes"}),
+            serde_json::json!({"to": ["today"], "key": "notes"}),
         )
         .await;
-    assert!(result.is_err() || {
-        let r = result.unwrap();
-        r.is_error.unwrap_or(false)
-    });
+    let json = fixture::Fixture::result_json(&result);
+    assert_eq!(json["creates"].as_array().unwrap().len(), 0);
+    assert_eq!(json["updates"].as_array().unwrap().len(), 0);
+}
+
+#[tokio::test]
+async fn attach_to_multiple_targets() {
+    let mut config = Configuration::default();
+    config.actions.insert(
+        "today".to_string(),
+        ActionDefinition::Attach(Attach {
+            title: "Daily".to_string(),
+            key_template: "daily".to_string(),
+            document_template: "# Daily\n\n{{content}}\n".to_string(),
+        }),
+    );
+    config.actions.insert(
+        "weekly".to_string(),
+        ActionDefinition::Attach(Attach {
+            title: "Weekly".to_string(),
+            key_template: "weekly".to_string(),
+            document_template: "# Weekly\n\n{{content}}\n".to_string(),
+        }),
+    );
+
+    let f = fixture::Fixture::with_documents_and_config(
+        vec![("notes", "# My Notes")],
+        config,
+    )
+    .await;
+
+    let result = f
+        .call_tool(
+            "iwe_attach",
+            serde_json::json!({"to": ["today", "weekly"], "key": "notes"}),
+        )
+        .await;
+    let json = fixture::Fixture::result_json(&result);
+    let creates = json["creates"].as_array().unwrap();
+    let mut keys: Vec<&str> = creates.iter().map(|c| c["key"].as_str().unwrap()).collect();
+    keys.sort();
+    assert_eq!(keys, vec!["daily", "weekly"]);
+}
+
+#[tokio::test]
+async fn attach_multiple_targets_one_already_attached_skips_one() {
+    let mut config = Configuration::default();
+    config.actions.insert(
+        "today".to_string(),
+        ActionDefinition::Attach(Attach {
+            title: "Daily".to_string(),
+            key_template: "daily".to_string(),
+            document_template: "# Daily\n\n{{content}}\n".to_string(),
+        }),
+    );
+    config.actions.insert(
+        "weekly".to_string(),
+        ActionDefinition::Attach(Attach {
+            title: "Weekly".to_string(),
+            key_template: "weekly".to_string(),
+            document_template: "# Weekly\n\n{{content}}\n".to_string(),
+        }),
+    );
+
+    let f = fixture::Fixture::with_documents_and_config(
+        vec![
+            ("notes", "# My Notes"),
+            ("daily", "# Daily\n\n[My Notes](notes)\n"),
+        ],
+        config,
+    )
+    .await;
+
+    let result = f
+        .call_tool(
+            "iwe_attach",
+            serde_json::json!({"to": ["today", "weekly"], "key": "notes"}),
+        )
+        .await;
+    let json = fixture::Fixture::result_json(&result);
+    // daily already had it (silent skip); weekly is brand new
+    let creates = json["creates"].as_array().unwrap();
+    assert_eq!(creates.len(), 1);
+    assert_eq!(creates[0]["key"], "weekly");
+    assert_eq!(json["updates"].as_array().unwrap().len(), 0);
 }
 
 #[tokio::test]
@@ -111,7 +192,7 @@ async fn attach_errors_on_missing_source() {
     let result = f
         .try_call_tool(
             "iwe_attach",
-            serde_json::json!({"action": "today", "key": "nonexistent"}),
+            serde_json::json!({"to": ["today"], "key": "nonexistent"}),
         )
         .await;
     assert!(result.is_err());
@@ -128,8 +209,22 @@ async fn attach_errors_on_unknown_action() {
     let result = f
         .try_call_tool(
             "iwe_attach",
-            serde_json::json!({"action": "unknown", "key": "notes"}),
+            serde_json::json!({"to": ["unknown"], "key": "notes"}),
         )
+        .await;
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn attach_errors_when_to_missing() {
+    let f = fixture::Fixture::with_documents_and_config(
+        vec![("notes", "# My Notes")],
+        config_with_attach(),
+    )
+    .await;
+
+    let result = f
+        .try_call_tool("iwe_attach", serde_json::json!({"key": "notes"}))
         .await;
     assert!(result.is_err());
 }

--- a/crates/iwec/tests/find_test.rs
+++ b/crates/iwec/tests/find_test.rs
@@ -70,3 +70,126 @@ async fn find_with_limit() {
     assert_eq!(output["results"].as_array().unwrap().len(), 2);
     assert_eq!(output["total"], 3);
 }
+
+fn keys(output: &serde_json::Value) -> Vec<String> {
+    let mut v: Vec<String> = output["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|r| r["key"].as_str().unwrap().to_string())
+        .collect();
+    v.sort();
+    v
+}
+
+#[tokio::test]
+async fn find_selector_in_intersects_two_parents() {
+    let f = Fixture::with_documents(vec![
+        ("a", "# A\n\n[X](x)\n\n[Y](y)\n"),
+        ("b", "# B\n\n[X](x)\n"),
+        ("x", "# X\n"),
+        ("y", "# Y\n"),
+    ])
+    .await;
+
+    let result = f
+        .call_tool("iwe_find", json!({"in": ["a", "b"]}))
+        .await;
+    let output = Fixture::result_json(&result);
+    assert_eq!(keys(&output), vec!["x"]);
+}
+
+#[tokio::test]
+async fn find_selector_in_any_unions_parents() {
+    let f = Fixture::with_documents(vec![
+        ("a", "# A\n\n[X](x)\n"),
+        ("b", "# B\n\n[Y](y)\n"),
+        ("x", "# X\n"),
+        ("y", "# Y\n"),
+        ("z", "# Z\n"),
+    ])
+    .await;
+
+    let result = f
+        .call_tool("iwe_find", json!({"in_any": ["a", "b"]}))
+        .await;
+    let output = Fixture::result_json(&result);
+    assert_eq!(keys(&output), vec!["x", "y"]);
+}
+
+#[tokio::test]
+async fn find_selector_not_in_subtracts() {
+    let f = Fixture::with_documents(vec![
+        ("a", "# A\n\n[X](x)\n\n[Y](y)\n"),
+        ("archive", "# Archive\n\n[Y](y)\n"),
+        ("x", "# X\n"),
+        ("y", "# Y\n"),
+    ])
+    .await;
+
+    let result = f
+        .call_tool(
+            "iwe_find",
+            json!({"in": ["a"], "not_in": ["archive"]}),
+        )
+        .await;
+    let output = Fixture::result_json(&result);
+    assert_eq!(keys(&output), vec!["x"]);
+}
+
+#[tokio::test]
+async fn find_selector_per_key_depth() {
+    // a → b → c. Per-key depth `a:1` keeps only direct children → {b}.
+    let f = Fixture::with_documents(vec![
+        ("a", "# A\n\n[B](b)\n"),
+        ("b", "# B\n\n[C](c)\n"),
+        ("c", "# C\n"),
+    ])
+    .await;
+
+    let result = f
+        .call_tool(
+            "iwe_find",
+            json!({"in": [{"key": "a", "depth": 1}]}),
+        )
+        .await;
+    let output = Fixture::result_json(&result);
+    assert_eq!(keys(&output), vec!["b"]);
+}
+
+#[tokio::test]
+async fn find_selector_max_depth() {
+    let f = Fixture::with_documents(vec![
+        ("a", "# A\n\n[B](b)\n"),
+        ("b", "# B\n\n[C](c)\n"),
+        ("c", "# C\n"),
+    ])
+    .await;
+
+    let result = f
+        .call_tool("iwe_find", json!({"in": ["a"], "max_depth": 1}))
+        .await;
+    let output = Fixture::result_json(&result);
+    assert_eq!(keys(&output), vec!["b"]);
+}
+
+#[tokio::test]
+async fn find_selector_combines_with_query() {
+    let f = Fixture::with_documents(vec![
+        ("a", "# A\n\n[Design notes](design)\n\n[Random](random)\n"),
+        ("design", "# Design notes\n"),
+        ("random", "# Random\n"),
+        ("design2", "# Design 2\n"),
+    ])
+    .await;
+
+    // Selector limits to A's subtree; query further filters to "design".
+    let result = f
+        .call_tool(
+            "iwe_find",
+            json!({"in": ["a"], "query": "design"}),
+        )
+        .await;
+    let output = Fixture::result_json(&result);
+    assert_eq!(keys(&output), vec!["design"]);
+}

--- a/crates/iwec/tests/retrieve_test.rs
+++ b/crates/iwec/tests/retrieve_test.rs
@@ -98,3 +98,77 @@ async fn retrieve_with_backlinks() {
     assert_eq!(backlinks.len(), 1);
     assert_eq!(backlinks[0]["key"], "1");
 }
+
+fn doc_keys(output: &serde_json::Value) -> Vec<String> {
+    let mut v: Vec<String> = output["documents"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|d| d["key"].as_str().unwrap().to_string())
+        .collect();
+    v.sort();
+    v
+}
+
+#[tokio::test]
+async fn retrieve_selector_only_uses_selected_set() {
+    let f = Fixture::with_documents(vec![
+        ("a", "# A\n\n[X](x)\n\n[Y](y)\n"),
+        ("b", "# B\n\n[X](x)\n"),
+        ("x", "# X\n"),
+        ("y", "# Y\n"),
+    ])
+    .await;
+
+    // No explicit keys; selector intersection picks {x}.
+    let result = f
+        .call_tool(
+            "iwe_retrieve",
+            json!({"in": ["a", "b"], "depth": 0, "context": 0, "backlinks": false}),
+        )
+        .await;
+    let output = Fixture::result_json(&result);
+    assert_eq!(doc_keys(&output), vec!["x"]);
+}
+
+#[tokio::test]
+async fn retrieve_explicit_keys_intersected_with_selector() {
+    let f = Fixture::with_documents(vec![
+        ("a", "# A\n\n[X](x)\n\n[Y](y)\n"),
+        ("x", "# X\n"),
+        ("y", "# Y\n"),
+        ("z", "# Z\n"),
+    ])
+    .await;
+
+    // Explicit asks for [x, y, z]; selector limits to A's subtree {x, y};
+    // intersection is {x, y}.
+    let result = f
+        .call_tool(
+            "iwe_retrieve",
+            json!({"keys": ["x", "y", "z"], "in": ["a"], "depth": 0, "context": 0, "backlinks": false}),
+        )
+        .await;
+    let output = Fixture::result_json(&result);
+    assert_eq!(doc_keys(&output), vec!["x", "y"]);
+}
+
+#[tokio::test]
+async fn retrieve_empty_intersection_yields_empty() {
+    let f = Fixture::with_documents(vec![
+        ("a", "# A\n\n[X](x)\n"),
+        ("b", "# B\n\n[Y](y)\n"),
+        ("x", "# X\n"),
+        ("y", "# Y\n"),
+    ])
+    .await;
+
+    let result = f
+        .call_tool(
+            "iwe_retrieve",
+            json!({"keys": ["x"], "in": ["b"], "depth": 0, "context": 0, "backlinks": false}),
+        )
+        .await;
+    let output = Fixture::result_json(&result);
+    assert!(output["documents"].as_array().unwrap().is_empty());
+}

--- a/crates/iwec/tests/tree_test.rs
+++ b/crates/iwec/tests/tree_test.rs
@@ -63,3 +63,48 @@ async fn tree_respects_depth_limit() {
     assert_eq!(children.len(), 1);
     assert_eq!(children[0]["key"], "2");
 }
+
+fn root_keys(output: &serde_json::Value) -> Vec<String> {
+    let mut v: Vec<String> = output
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|t| t["key"].as_str().unwrap().to_string())
+        .collect();
+    v.sort();
+    v
+}
+
+#[tokio::test]
+async fn tree_selector_uses_selected_set_as_roots() {
+    let f = Fixture::with_documents(vec![
+        ("a", "# A\n\n[X](x)\n\n[Y](y)\n"),
+        ("b", "# B\n\n[X](x)\n"),
+        ("x", "# X\n"),
+        ("y", "# Y\n"),
+    ])
+    .await;
+
+    let result = f
+        .call_tool("iwe_tree", json!({"in": ["a", "b"]}))
+        .await;
+    let output = Fixture::result_json(&result);
+    assert_eq!(root_keys(&output), vec!["x"]);
+}
+
+#[tokio::test]
+async fn tree_explicit_key_intersects_selector() {
+    let f = Fixture::with_documents(vec![
+        ("a", "# A\n\n[X](x)\n"),
+        ("x", "# X\n"),
+        ("y", "# Y\n"),
+    ])
+    .await;
+
+    // Explicit Y, selector A's subtree → empty intersection.
+    let result = f
+        .call_tool("iwe_tree", json!({"keys": ["y"], "in": ["a"]}))
+        .await;
+    let output = Fixture::result_json(&result);
+    assert!(output.as_array().unwrap().is_empty());
+}

--- a/crates/liwe/src/find.rs
+++ b/crates/liwe/src/find.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use crate::graph::{Graph, GraphContext};
 use crate::model::node::{NodeIter, NodePointer};
 use crate::model::{Key, NodeId};
+use crate::selector::Selector;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ParentDocumentInfo {
@@ -37,6 +38,7 @@ pub struct FindOptions {
     pub roots: bool,
     pub refs_to: Option<Key>,
     pub refs_from: Option<Key>,
+    pub selector: Selector,
     pub limit: Option<usize>,
 }
 
@@ -52,11 +54,22 @@ impl<'a> DocumentFinder<'a> {
     pub fn find(&self, options: &FindOptions) -> FindOutput {
         let matcher = SkimMatcherV2::default();
 
+        let candidate_set = if options.selector.is_empty() {
+            None
+        } else {
+            Some(options.selector.resolve(self.graph))
+        };
+
         let mut results: Vec<(Key, i64)> = self
             .graph
             .keys()
             .into_iter()
             .filter_map(|key| {
+                if let Some(set) = &candidate_set {
+                    if !set.contains(&key) {
+                        return None;
+                    }
+                }
                 if options.roots && !self.is_root(&key) {
                     return None;
                 }

--- a/crates/liwe/src/lib.rs
+++ b/crates/liwe/src/lib.rs
@@ -8,5 +8,6 @@ pub mod model;
 pub mod operations;
 pub mod parser;
 pub mod retrieve;
+pub mod selector;
 pub mod state;
 pub mod stats;

--- a/crates/liwe/src/retrieve.rs
+++ b/crates/liwe/src/retrieve.rs
@@ -5,6 +5,7 @@ use serde::Serialize;
 use crate::graph::{Graph, GraphContext};
 use crate::model::node::{NodeIter, NodePointer};
 use crate::model::{Key, NodeId};
+use crate::selector::Selector;
 
 #[derive(Debug, Clone, Serialize)]
 pub struct ParentDocumentInfo {
@@ -49,6 +50,7 @@ pub struct RetrieveOptions {
     pub backlinks: bool,
     pub exclude: HashSet<Key>,
     pub no_content: bool,
+    pub selector: Selector,
 }
 
 pub struct DocumentReader<'a> {
@@ -80,10 +82,26 @@ impl<'a> DocumentReader<'a> {
     }
 
     pub fn retrieve_many(&self, keys: &[Key], options: &RetrieveOptions) -> RetrieveOutput {
+        let effective_keys: Vec<Key> = if options.selector.is_empty() {
+            keys.to_vec()
+        } else {
+            let selector_set = options.selector.resolve(self.graph);
+            if keys.is_empty() {
+                let mut v: Vec<Key> = selector_set.into_iter().collect();
+                v.sort();
+                v
+            } else {
+                keys.iter()
+                    .filter(|k| selector_set.contains(k))
+                    .cloned()
+                    .collect()
+            }
+        };
+
         let mut documents = Vec::new();
         let mut seen_keys = HashSet::new();
 
-        for key in keys {
+        for key in &effective_keys {
             let keys_to_process = self.collect_document_keys(key, options);
 
             for doc_key in keys_to_process {

--- a/crates/liwe/src/selector.rs
+++ b/crates/liwe/src/selector.rs
@@ -1,0 +1,337 @@
+use std::collections::HashSet;
+
+use crate::graph::Graph;
+use crate::model::Key;
+
+#[derive(Debug, Clone)]
+pub struct KeyDepth {
+    pub key: Key,
+    pub depth: Option<u8>,
+}
+
+impl KeyDepth {
+    pub fn bare(key: Key) -> Self {
+        Self { key, depth: None }
+    }
+
+    pub fn with_depth(key: Key, depth: u8) -> Self {
+        Self { key, depth: Some(depth) }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct Selector {
+    pub in_: Vec<KeyDepth>,
+    pub in_any: Vec<KeyDepth>,
+    pub not_in: Vec<KeyDepth>,
+    pub max_depth: Option<u8>,
+}
+
+impl Selector {
+    pub fn is_empty(&self) -> bool {
+        self.in_.is_empty()
+            && self.in_any.is_empty()
+            && self.not_in.is_empty()
+            && self.max_depth.is_none()
+    }
+
+    pub fn resolve(&self, graph: &Graph) -> HashSet<Key> {
+        let mut candidates: Option<HashSet<Key>> = None;
+
+        for kd in &self.in_ {
+            let depth = kd.depth.or(self.max_depth);
+            let set = descendants_at_depth(graph, &kd.key, depth);
+            candidates = Some(match candidates {
+                None => set,
+                Some(c) => c.intersection(&set).cloned().collect(),
+            });
+        }
+
+        if !self.in_any.is_empty() {
+            let mut union: HashSet<Key> = HashSet::new();
+            for kd in &self.in_any {
+                let depth = kd.depth.or(self.max_depth);
+                union.extend(descendants_at_depth(graph, &kd.key, depth));
+            }
+            candidates = Some(match candidates {
+                None => union,
+                Some(c) => c.intersection(&union).cloned().collect(),
+            });
+        }
+
+        let mut result =
+            candidates.unwrap_or_else(|| graph.keys().into_iter().collect());
+
+        for kd in &self.not_in {
+            let depth = kd.depth.or(self.max_depth);
+            let exclude = descendants_at_depth(graph, &kd.key, depth);
+            result = result.difference(&exclude).cloned().collect();
+        }
+
+        result
+    }
+}
+
+pub fn descendants_at_depth(graph: &Graph, origin: &Key, depth: Option<u8>) -> HashSet<Key> {
+    let mut result: HashSet<Key> = HashSet::new();
+    let mut frontier: Vec<Key> = vec![origin.clone()];
+    let mut walked: u8 = 0;
+
+    loop {
+        if let Some(d) = depth {
+            if walked >= d {
+                break;
+            }
+        }
+
+        let mut next: Vec<Key> = Vec::new();
+        for current in &frontier {
+            for ref_id in graph.get_block_references_in(current) {
+                if let Some(ref_key) = graph.graph_node(ref_id).ref_key() {
+                    if &ref_key == origin {
+                        continue;
+                    }
+                    if result.insert(ref_key.clone()) {
+                        next.push(ref_key);
+                    }
+                }
+            }
+        }
+
+        if next.is_empty() {
+            break;
+        }
+        frontier = next;
+        walked = walked.saturating_add(1);
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::config::MarkdownOptions;
+    use std::collections::HashMap;
+
+    fn build(docs: &[(&str, &str)]) -> Graph {
+        let map: HashMap<String, String> = docs
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        Graph::import(&map, MarkdownOptions::default(), None)
+    }
+
+    fn k(s: &str) -> Key {
+        Key::name(s)
+    }
+
+    fn keys(set: &HashSet<Key>) -> Vec<String> {
+        let mut v: Vec<String> = set.iter().map(|k| k.to_string()).collect();
+        v.sort();
+        v
+    }
+
+    #[test]
+    fn descendants_unbounded() {
+        let graph = build(&[
+            ("a", "# A\n\n[B](b)\n"),
+            ("b", "# B\n\n[C](c)\n"),
+            ("c", "# C\n"),
+        ]);
+        let result = descendants_at_depth(&graph, &k("a"), None);
+        assert_eq!(keys(&result), vec!["b", "c"]);
+    }
+
+    #[test]
+    fn descendants_depth_one() {
+        let graph = build(&[
+            ("a", "# A\n\n[B](b)\n"),
+            ("b", "# B\n\n[C](c)\n"),
+            ("c", "# C\n"),
+        ]);
+        let result = descendants_at_depth(&graph, &k("a"), Some(1));
+        assert_eq!(keys(&result), vec!["b"]);
+    }
+
+    #[test]
+    fn descendants_depth_zero_is_empty() {
+        let graph = build(&[
+            ("a", "# A\n\n[B](b)\n"),
+            ("b", "# B\n"),
+        ]);
+        let result = descendants_at_depth(&graph, &k("a"), Some(0));
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn descendants_handle_cycles() {
+        let graph = build(&[
+            ("a", "# A\n\n[B](b)\n"),
+            ("b", "# B\n\n[A](a)\n"),
+        ]);
+        let result = descendants_at_depth(&graph, &k("a"), None);
+        assert_eq!(keys(&result), vec!["b"]);
+    }
+
+    #[test]
+    fn descendants_diamond_visits_each_once() {
+        let graph = build(&[
+            ("a", "# A\n\n[B](b)\n\n[C](c)\n"),
+            ("b", "# B\n\n[D](d)\n"),
+            ("c", "# C\n\n[D](d)\n"),
+            ("d", "# D\n"),
+        ]);
+        let result = descendants_at_depth(&graph, &k("a"), None);
+        assert_eq!(keys(&result), vec!["b", "c", "d"]);
+    }
+
+    #[test]
+    fn descendants_short_path_does_not_starve_long_path() {
+        // X reachable at depth 1 via Y, and at depth 3 via B→C→D→X→Z.
+        // Y→X is the short path; B→C→D→X→Z must still expose Z within depth 4.
+        let graph = build(&[
+            ("a", "# A\n\n[B](b)\n\n[Y](y)\n"),
+            ("b", "# B\n\n[C](c)\n"),
+            ("c", "# C\n\n[D](d)\n"),
+            ("d", "# D\n\n[X](x)\n"),
+            ("y", "# Y\n\n[X](x)\n"),
+            ("x", "# X\n\n[Z](z)\n"),
+            ("z", "# Z\n"),
+        ]);
+        let result = descendants_at_depth(&graph, &k("a"), Some(4));
+        // BFS layer order: A→{B,Y}→{C,X}→{D,Z}→{}.
+        // Expect everything below A is reached within 4 hops.
+        assert_eq!(keys(&result), vec!["b", "c", "d", "x", "y", "z"]);
+    }
+
+    #[test]
+    fn descendants_missing_key_returns_empty() {
+        let graph = build(&[("a", "# A\n")]);
+        let result = descendants_at_depth(&graph, &k("missing"), None);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn selector_empty_returns_all_keys() {
+        let graph = build(&[
+            ("a", "# A\n"),
+            ("b", "# B\n"),
+            ("c", "# C\n"),
+        ]);
+        let result = Selector::default().resolve(&graph);
+        assert_eq!(keys(&result), vec!["a", "b", "c"]);
+    }
+
+    #[test]
+    fn selector_in_intersects_two_parents() {
+        // X is sub-doc of both A and B; Y is sub-doc of A only.
+        let graph = build(&[
+            ("a", "# A\n\n[X](x)\n\n[Y](y)\n"),
+            ("b", "# B\n\n[X](x)\n"),
+            ("x", "# X\n"),
+            ("y", "# Y\n"),
+        ]);
+        let sel = Selector {
+            in_: vec![KeyDepth::bare(k("a")), KeyDepth::bare(k("b"))],
+            ..Default::default()
+        };
+        let result = sel.resolve(&graph);
+        assert_eq!(keys(&result), vec!["x"]);
+    }
+
+    #[test]
+    fn selector_in_any_unions_two_parents() {
+        let graph = build(&[
+            ("a", "# A\n\n[X](x)\n"),
+            ("b", "# B\n\n[Y](y)\n"),
+            ("x", "# X\n"),
+            ("y", "# Y\n"),
+            ("z", "# Z\n"),
+        ]);
+        let sel = Selector {
+            in_any: vec![KeyDepth::bare(k("a")), KeyDepth::bare(k("b"))],
+            ..Default::default()
+        };
+        let result = sel.resolve(&graph);
+        assert_eq!(keys(&result), vec!["x", "y"]);
+    }
+
+    #[test]
+    fn selector_not_in_subtracts() {
+        let graph = build(&[
+            ("a", "# A\n\n[X](x)\n\n[Y](y)\n"),
+            ("archive", "# Archive\n\n[Y](y)\n"),
+            ("x", "# X\n"),
+            ("y", "# Y\n"),
+        ]);
+        let sel = Selector {
+            in_: vec![KeyDepth::bare(k("a"))],
+            not_in: vec![KeyDepth::bare(k("archive"))],
+            ..Default::default()
+        };
+        let result = sel.resolve(&graph);
+        assert_eq!(keys(&result), vec!["x"]);
+    }
+
+    #[test]
+    fn selector_per_key_depth_overrides_max_depth() {
+        // A→B→C, X→Y. max_depth=1 normally limits A's set to {B}.
+        // Per-key depth=2 on A widens to {B, C}.
+        let graph = build(&[
+            ("a", "# A\n\n[B](b)\n"),
+            ("b", "# B\n\n[C](c)\n"),
+            ("c", "# C\n"),
+        ]);
+        let sel = Selector {
+            in_: vec![KeyDepth::with_depth(k("a"), 2)],
+            max_depth: Some(1),
+            ..Default::default()
+        };
+        let result = sel.resolve(&graph);
+        assert_eq!(keys(&result), vec!["b", "c"]);
+    }
+
+    #[test]
+    fn selector_max_depth_applies_when_no_per_key_override() {
+        let graph = build(&[
+            ("a", "# A\n\n[B](b)\n"),
+            ("b", "# B\n\n[C](c)\n"),
+            ("c", "# C\n"),
+        ]);
+        let sel = Selector {
+            in_: vec![KeyDepth::bare(k("a"))],
+            max_depth: Some(1),
+            ..Default::default()
+        };
+        let result = sel.resolve(&graph);
+        assert_eq!(keys(&result), vec!["b"]);
+    }
+
+    #[test]
+    fn selector_empty_intersection_returns_empty() {
+        let graph = build(&[
+            ("a", "# A\n\n[X](x)\n"),
+            ("b", "# B\n\n[Y](y)\n"),
+            ("x", "# X\n"),
+            ("y", "# Y\n"),
+        ]);
+        let sel = Selector {
+            in_: vec![KeyDepth::bare(k("a")), KeyDepth::bare(k("b"))],
+            ..Default::default()
+        };
+        let result = sel.resolve(&graph);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn selector_missing_parent_yields_empty_intersection() {
+        let graph = build(&[("a", "# A\n\n[X](x)\n"), ("x", "# X\n")]);
+        let sel = Selector {
+            in_: vec![KeyDepth::bare(k("a")), KeyDepth::bare(k("nonexistent"))],
+            ..Default::default()
+        };
+        let result = sel.resolve(&graph);
+        assert!(result.is_empty());
+    }
+}

--- a/docs/cli-attach.md
+++ b/docs/cli-attach.md
@@ -1,0 +1,63 @@
+# IWE Attach
+
+Attach a document as a block reference under one or more configured **attach actions**.
+
+## Usage
+
+``` bash
+iwe attach --list
+iwe attach --to <NAME> [--to <NAME> ...] -k <KEY>
+```
+
+## Options
+
+| Flag                   | Description                                                          | Default |
+| ---------------------- | -------------------------------------------------------------------- | ------- |
+| `--to <NAME>`          | Configured attach action to attach to. Repeatable for multiple targets. | (required when not in list mode) |
+| `-k, --key <KEY>`      | Source document key to attach                                        | (required when not in list mode) |
+| `--list`               | List configured attach actions and the resolved target keys, then exit | false |
+| `--dry-run`            | Preview without writing                                              | false   |
+| `--quiet`              | Suppress progress output                                             | false   |
+
+## How it works
+
+For each `--to <NAME>`:
+
+1. Look up `<NAME>` in `[actions]` of `.iwe/config.toml`. The action must be of type `attach`.
+2. Render the action's `key_template` to compute the target document key (e.g. `daily/{{today}}` becomes `daily/2026-04-25`).
+3. If the target document doesn't exist yet, it is created with the action's `title` as the H1 and the new block reference as the body.
+4. If the target exists, the new block reference is appended.
+5. If the source is **already attached** in the target, that target is silently skipped — no error, no warning, no duplicate write.
+
+The reference text on the new block is the source document's title.
+
+## Configuration
+
+Define an attach action in `.iwe/config.toml`:
+
+``` toml
+[actions.today]
+type = "attach"
+title = "{{today}}"
+key_template = "daily/{{today}}"
+```
+
+## Examples
+
+``` bash
+# Discover available attach actions
+iwe attach --list
+
+# Attach a document under one configured target
+iwe attach --to today -k meetings/standup
+
+# Attach the same document under multiple targets at once
+iwe attach --to today --to weekly -k meetings/standup
+
+# Preview without writing
+iwe attach --to today --to weekly -k meetings/standup --dry-run
+```
+
+## Relationship to MCP
+
+This command mirrors the `iwe_attach` MCP tool. The MCP tool's `to` field accepts an array of action names with the same semantics.

--- a/docs/cli-export.md
+++ b/docs/cli-export.md
@@ -5,7 +5,7 @@ Exports graph structure in various formats for visualization and analysis.
 ## Usage
 
 ``` bash
-iwe export [OPTIONS] <FORMAT>
+iwe export -f <FORMAT> [OPTIONS]
 ```
 
 ## Available Formats
@@ -17,12 +17,19 @@ iwe export [OPTIONS] <FORMAT>
 
 ## Options
 
-| Option                  | Default   | Description                                           |
-| ----------------------- | --------- | ----------------------------------------------------- |
-| `-k, --key <KEY>`       | all roots | Filter to specific document and its connections       |
-| `-d, --depth <DEPTH>`   | `0`       | Maximum depth to include (0 = unlimited)              |
-| `--include-headers`     | false     | Include section headers and create detailed subgraphs |
-| `-v, --verbose <LEVEL>` | `0`       | Verbosity level                                       |
+| Option                  | Default   | Description                                                       |
+| ----------------------- | --------- | ----------------------------------------------------------------- |
+| `-f, --format <FORMAT>` | `dot`     | Output format                                                     |
+| `-k, --key <KEY>`       | all roots | Filter to specific document(s). Repeatable.                       |
+| `-d, --depth <DEPTH>`   | `0`       | Maximum depth to include (0 = unlimited)                          |
+| `--in <KEY[:DEPTH]>`    | -         | Restrict to sub-documents of EVERY listed key (AND). Repeatable.  |
+| `--in-any <KEY...>`     | -         | Restrict to sub-documents of ANY listed key (OR). Repeatable.     |
+| `--not-in <KEY...>`     | -         | Exclude sub-documents of any listed key (NOT). Repeatable.        |
+| `--max-depth <N>`       | -         | Default depth for `--in` family. Unbounded if omitted.            |
+| `--include-headers`     | false     | Include section headers and create detailed subgraphs             |
+| `-v, --verbose <LEVEL>` | `0`       | Verbosity level                                                   |
+
+> **Breaking change:** in earlier versions, `iwe export <FORMAT>` accepted the format as a positional argument. The format is now the `-f / --format` flag with a default of `dot`. The previous `iwe export dot` becomes `iwe export -f dot` (or simply `iwe export`).
 
 
 ## DOT Output Format

--- a/docs/cli-find.md
+++ b/docs/cli-find.md
@@ -10,14 +10,41 @@ iwe find [QUERY] [OPTIONS]
 
 ## Options
 
-| Flag                 | Description                               | Default          |
-| -------------------- | ----------------------------------------- | ---------------- |
-| `[QUERY]`            | Fuzzy search on document title and key    | none (lists all) |
-| `--roots`            | Only show root documents (no parents)     | false            |
-| `--refs-to <KEY>`    | Documents that reference this key         | none             |
-| `--refs-from <KEY>`  | Documents referenced by this key          | none             |
-| `-l, --limit <N>`    | Maximum number of results                 | 50               |
-| `-f, --format <FMT>` | Output format: `markdown`, `keys`, `json` | markdown         |
+| Flag                 | Description                                                      | Default          |
+| -------------------- | ---------------------------------------------------------------- | ---------------- |
+| `[QUERY]`            | Fuzzy search on document title and key                           | none (lists all) |
+| `--roots`            | Only show root documents (no parents)                            | false            |
+| `--refs-to <KEY>`    | Documents that reference this key (direct, includes inline)      | none             |
+| `--refs-from <KEY>`  | Documents referenced by this key (direct, includes inline)       | none             |
+| `--in <KEY[:DEPTH]>` | Sub-documents of EVERY listed key (AND). Repeatable.             | none             |
+| `--in-any <KEY...>`  | Sub-documents of AT LEAST ONE listed key (OR). Repeatable.       | none             |
+| `--not-in <KEY...>`  | Exclude sub-documents of any listed key (NOT). Repeatable.       | none             |
+| `--max-depth <N>`    | Default depth for `--in` / `--in-any` / `--not-in`. Unbounded if omitted. | none      |
+| `-l, --limit <N>`    | Maximum number of results                                        | 50               |
+| `-f, --format <FMT>` | Output format: `markdown`, `keys`, `json`                        | markdown         |
+
+## Structural set selector (`--in` family)
+
+The `--in`, `--in-any`, `--not-in`, and `--max-depth` flags together form a **set selector** over block-reference relationships. They answer questions like "documents that are sub-documents of A and B within depth N":
+
+``` bash
+# Sub-documents of A AND B (intersection, unbounded depth)
+iwe find --in projects/alpha --in people/dmytro
+
+# Same, bounded to 2 hops from each parent
+iwe find --in projects/alpha --in people/dmytro --max-depth 2
+
+# Per-parent depth: A within 3 hops, Dmytro within 1
+iwe find --in projects/alpha:3 --in people/dmytro:1
+
+# Sub-documents of A OR B (union)
+iwe find --in-any projects/alpha --in-any projects/beta
+
+# Sub-documents of A but NOT B
+iwe find --in projects/alpha --not-in archive
+```
+
+The same selector flags are also accepted by `iwe retrieve`, `iwe tree`, and `iwe export`. See those commands for set-aware reads.
 
 
 ## How It Works

--- a/docs/cli-retrieve.md
+++ b/docs/cli-retrieve.md
@@ -23,6 +23,22 @@ Without `-k`, reads the document key from stdin (for piping).
 | `-f, --format <FMT>`  | Output format: `markdown`, `keys`, `json`                              | markdown |
 | `--no-content`        | Exclude content, show child documents instead (metadata only)          | false    |
 | `--dry-run`           | Show document count and total lines without content                    | false    |
+| `--in <KEY[:DEPTH]>`  | Sub-documents of EVERY listed key (AND). Repeatable.                   | none     |
+| `--in-any <KEY...>`   | Sub-documents of AT LEAST ONE listed key (OR). Repeatable.             | none     |
+| `--not-in <KEY...>`   | Exclude sub-documents of any listed key (NOT). Repeatable.             | none     |
+| `--max-depth <N>`     | Default depth for `--in` family. Unbounded if omitted.                 | none     |
+
+### Structural set selector
+
+When `--in` / `--in-any` / `--not-in` flags are provided, `retrieve` reads the documents that match the selector. With both `-k` and `--in`, the result is the **intersection** — explicit keys filtered through the selector. Empty intersection produces an empty result.
+
+``` bash
+# Read content of all docs that are sub-documents of A AND B
+iwe retrieve --in projects/alpha --in people/dmytro --depth 0
+
+# Read explicit keys but only those inside projects/alpha's subtree
+iwe retrieve -k x -k y -k z --in projects/alpha
+```
 
 
 ## How It Works

--- a/docs/cli-stats.md
+++ b/docs/cli-stats.md
@@ -10,9 +10,11 @@ iwe stats [OPTIONS]
 
 ## Options
 
-- `-f, --format <FORMAT>`: Output format (default: markdown)
+- `-f, --format <FORMAT>`: Output format (default: `markdown`)
   - `markdown`: Human-readable formatted statistics
   - `csv`: Machine-readable CSV format with per-document statistics
+  - `json`: JSON output (aggregate stats only; ignored when `-k` is given — per-key stats always serialize as JSON)
+- `-k, --key <KEY>`: Document key for per-document statistics (always JSON output). Omit for aggregate graph statistics.
 
 ## What it shows
 

--- a/docs/cli-tree.md
+++ b/docs/cli-tree.md
@@ -10,12 +10,18 @@ iwe tree [OPTIONS]
 
 ## Options
 
-| Option                  | Default    | Description                                           |
-| ----------------------- | ---------- | ----------------------------------------------------- |
-| `-f, --format <FORMAT>` | `markdown` | Output format: markdown, keys, json                   |
-| `-k, --key <KEY>`       | -          | Start tree from specific document(s), can be repeated |
-| `-d, --depth <DEPTH>`   | `4`        | Maximum depth to traverse                             |
-| `-v, --verbose <LEVEL>` | `0`        | Verbosity level (1=info, 2=debug)                     |
+| Option                  | Default    | Description                                                            |
+| ----------------------- | ---------- | ---------------------------------------------------------------------- |
+| `-f, --format <FORMAT>` | `markdown` | Output format: markdown, keys, json                                    |
+| `-k, --key <KEY>`       | -          | Start tree from specific document(s), can be repeated                  |
+| `-d, --depth <DEPTH>`   | `4`        | Maximum depth to traverse                                              |
+| `--in <KEY[:DEPTH]>`    | -          | Use sub-documents of EVERY listed key (AND) as tree roots. Repeatable. |
+| `--in-any <KEY...>`     | -          | Use sub-documents of ANY listed key (OR) as tree roots. Repeatable.    |
+| `--not-in <KEY...>`     | -          | Exclude sub-documents of any listed key (NOT). Repeatable.             |
+| `--max-depth <N>`       | -          | Default depth for `--in` family. Unbounded if omitted.                 |
+| `-v, --verbose <LEVEL>` | `0`        | Verbosity level (1=info, 2=debug)                                      |
+
+When `--in` / `--in-any` / `--not-in` is provided, the selector resolves to a set of keys and those keys are used as the tree roots. Combining `-k` with the selector intersects the two — empty intersection yields an empty tree.
 
 
 ## Output Formats

--- a/docs/cli-update.md
+++ b/docs/cli-update.md
@@ -1,0 +1,40 @@
+# IWE Update
+
+Overwrite the full markdown content of an existing document.
+
+## Usage
+
+``` bash
+iwe update -k <KEY> -c <CONTENT>
+iwe update -k <KEY> -c -          # read content from stdin
+```
+
+## Options
+
+| Flag                   | Description                                | Default |
+| ---------------------- | ------------------------------------------ | ------- |
+| `-k, --key <KEY>`      | Document key to update                     | (required) |
+| `-c, --content <STR>`  | New full markdown content. Use `-` for stdin. | (required) |
+| `--dry-run`            | Preview without writing                    | false   |
+| `--quiet`              | Suppress progress output                   | false   |
+
+## Behavior
+
+`update` overwrites the document at `<KEY>` with the provided content. The graph is not mutated by `update` itself; the file change is picked up on the next read. Use `iwe normalize` afterward if you want to canonicalize the output.
+
+## Examples
+
+``` bash
+# Replace a doc with a fixed string
+iwe update -k notes/draft -c "# Draft\n\nNew content."
+
+# Pipe content from another command
+cat new-content.md | iwe update -k notes/draft -c -
+
+# Preview without writing
+iwe update -k notes/draft -c "..." --dry-run
+```
+
+## Relationship to MCP
+
+This command mirrors the `iwe_update` MCP tool. Both take the same arguments and produce the same on-disk result.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -11,11 +11,13 @@ IWE provides a powerful command-line interface for managing markdown-based knowl
 5.  **Normalize all documents**: `iwe normalize`
 6.  **View document hierarchy**: `iwe tree`
 7.  **Analyze your knowledge base**: `iwe stats`
-8.  **Export graph visualization**: `iwe export dot`
+8.  **Export graph visualization**: `iwe export -f dot`
 9.  **Rename a document**: `iwe rename old-key new-key`
 10. **Delete a document**: `iwe delete document-key`
 11. **Extract a section**: `iwe extract document --section "Title"`
 12. **Inline a reference**: `iwe inline document --reference "other-doc"`
+13. **Update a document**: `iwe update -k document-key -c "new content"`
+14. **Attach via configured action**: `iwe attach --action today -k document-key`
 
 ## Installation & Setup
 


### PR DESCRIPTION
Introduce a shared selector (--in / --in-any / --not-in / --max-depth) on iwe_find, iwe_retrieve, iwe_tree, and iwe export. Answers "sub-documents of A and B within depth N" via a new liwe::selector module with cycle-safe BFS traversal. With explicit --key, the selector intersects -- empty intersection yields an empty result.

CLI/MCP parity:
- new `iwe update` and `iwe attach` mirroring iwe_update / iwe_attach
- iwe_attach: `action: String` -> `to: Vec<String>` (multiple targets, silent skip on already-attached). `text` field removed; reference text is always the source title.

Cleanups:
- `iwe export <FORMAT>` -> `iwe export -f <FORMAT>` (positional removed)
- `iwe export -k` is now repeatable
- `iwe stats -k <KEY>` and `iwe stats -f json` added

Note: this contains two breaking changes worth flagging in the PR description even though the title doesn't use !: syntax (the repo's recent commits don't):

1. iwe export <FORMAT> positional → -f <FORMAT> flag
2. MCP iwe_attach action: string → to: string[], and text field removed