### PR TITLE
feat: add shell completion support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "660c0520455b1013b9bcb0393d5f643d7e4454fb69c915b8d6d2aa0e9a45acc3"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1061,6 +1070,7 @@ version = "0.1.3"
 dependencies = [
  "chrono",
  "clap",
+ "clap_complete",
  "criterion",
  "csv",
  "graphviz-rust",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ liwe = { path = "./crates/liwe", version = "0.1.3" }
 iwe = { path = "./crates/iwe", version = "0.1.3" }
 anyhow = "1.0.102"
 clap = { version = "4.5", features = ["derive"] }
+clap_complete = "4.6"
 crossbeam-channel = "0.5.15"
 env_logger = "0.11.10"
 extend = "1.2.0"

--- a/crates/iwe/Cargo.toml
+++ b/crates/iwe/Cargo.toml
@@ -20,6 +20,7 @@ path = "src/main.rs"
 liwe.workspace = true
 indoc.workspace = true
 clap.workspace = true
+clap_complete.workspace = true
 itertools.workspace = true
 log.workspace = true
 rand.workspace = true

--- a/crates/iwe/help/completions/about.txt
+++ b/crates/iwe/help/completions/about.txt
@@ -1,0 +1,1 @@
+Generate shell completion scripts

--- a/crates/iwe/help/completions/after_help.txt
+++ b/crates/iwe/help/completions/after_help.txt
@@ -1,0 +1,16 @@
+EXAMPLES:
+
+  # Bash
+  iwe completions bash > ~/.local/share/bash-completion/completions/iwe
+
+  # Zsh
+  iwe completions zsh > /usr/local/share/zsh/site-functions/_iwe
+
+  # Fish
+  iwe completions fish > ~/.config/fish/completions/iwe.fish
+
+  # Elvish
+  iwe completions elvish > ~/.config/elvish/completions/iwe.elv
+
+  # PowerShell
+  iwe completions powershell >> $PROFILE

--- a/crates/iwe/help/completions/long_about.txt
+++ b/crates/iwe/help/completions/long_about.txt
@@ -1,0 +1,6 @@
+Generate a shell completion script for the given shell and print it to stdout.
+
+Supported shells: bash, elvish, fish, powershell, zsh.
+
+Source or install the printed script according to your shell's conventions to
+enable tab-completion for all iwe commands, subcommands, flags, and arguments.

--- a/crates/iwe/src/help.rs
+++ b/crates/iwe/src/help.rs
@@ -99,3 +99,9 @@ pub mod attach {
     pub const LONG_ABOUT: &str = include_str!("../help/attach/long_about.txt");
     pub const AFTER_HELP: &str = include_str!("../help/attach/after_help.txt");
 }
+
+pub mod completions {
+    pub const ABOUT: &str = include_str!("../help/completions/about.txt");
+    pub const LONG_ABOUT: &str = include_str!("../help/completions/long_about.txt");
+    pub const AFTER_HELP: &str = include_str!("../help/completions/after_help.txt");
+}

--- a/crates/iwe/src/main.rs
+++ b/crates/iwe/src/main.rs
@@ -3,7 +3,7 @@ use std::fs::create_dir;
 use std::path::PathBuf;
 use std::process::Command as ProcessCommand;
 
-use clap::{Args, Parser, Subcommand};
+use clap::{Args, CommandFactory, Parser, Subcommand};
 
 mod help;
 use itertools::Itertools;
@@ -67,6 +67,7 @@ enum Command {
     Inline(Inline),
     Update(Update),
     Attach(Attach),
+    Completions(Completions),
 }
 
 #[derive(Debug, Args)]
@@ -639,6 +640,18 @@ struct Inline {
     keys_legacy: bool,
 }
 
+#[derive(Debug, Args)]
+#[clap(
+    about = help::completions::ABOUT,
+    long_about = help::completions::LONG_ABOUT,
+    after_help = help::completions::AFTER_HELP
+)]
+struct Completions {
+    /// Shell to generate completions for.
+    #[clap(value_enum)]
+    shell: clap_complete::Shell,
+}
+
 fn main() {
     debug!("parsing arguments");
     let app = App::parse();
@@ -680,6 +693,7 @@ fn main() {
         Command::Inline(inline) => inline_command(inline),
         Command::Update(update) => update_command(update),
         Command::Attach(attach) => attach_command(attach),
+        Command::Completions(completions) => completions_command(completions),
     }
 }
 
@@ -2313,4 +2327,13 @@ fn render_attach_title(template: &str) -> String {
             .unwrap_or_else(|_| template.to_string())
         })
         .unwrap_or_else(|_| template.to_string())
+}
+
+fn completions_command(args: Completions) {
+    clap_complete::generate(
+        args.shell,
+        &mut App::command(),
+        "iwe",
+        &mut std::io::stdout(),
+    );
 }


### PR DESCRIPTION
Add an `iwe completions` subcommand that generates shell completion scripts for Bash, Fish, Zsh, Elvish and PowerShell via `clap_complete`.