### PR TITLE
feat: Support testing definitions and hover tips after CJK text

### DIFF
--- a/crates/iwec/src/watcher.rs
+++ b/crates/iwec/src/watcher.rs
@@ -12,10 +12,7 @@ fn path_to_key(path: &Path, base_path: &Path) -> Option<Key> {
     }
 
     let relative = path.strip_prefix(base_path).ok()?;
-    let key_str = relative
-        .with_extension("")
-        .to_string_lossy()
-        .to_string();
+    let key_str = relative_key(relative);
 
     Some(Key::name(&key_str))
 }
@@ -54,11 +51,7 @@ pub fn start_with_config(
     });
 }
 
-pub fn start_polling(
-    graph: Arc<Mutex<Graph>>,
-    base_path: PathBuf,
-    interval: std::time::Duration,
-) {
+pub fn start_polling(graph: Arc<Mutex<Graph>>, base_path: PathBuf, interval: std::time::Duration) {
     let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<Event>();
 
     let config = notify::Config::default()
@@ -109,5 +102,30 @@ async fn handle_event(graph: &Arc<Mutex<Graph>>, base_path: &Path, event: Event)
             }
             _ => {}
         }
+    }
+}
+
+fn relative_key(path: &Path) -> String {
+    let without_extension = path.with_extension("");
+    let parts = without_extension
+        .iter()
+        .map(|part| part.to_string_lossy())
+        .collect::<Vec<_>>();
+
+    parts.join("/")
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_to_key_normalizes_nested_paths_to_forward_slashes() {
+        let base = Path::new(r"D:\base");
+        let path = Path::new(r"D:\base\sub\dir\note.md");
+
+        let key = path_to_key(path, base).expect("key");
+
+        assert_eq!(key.to_string(), "sub/dir/note");
     }
 }

--- a/crates/iwes/src/router/server.rs
+++ b/crates/iwes/src/router/server.rs
@@ -1,6 +1,6 @@
 use actions::{all_action_types, ActionContext, ActionProvider};
-use std::time::SystemTime;
 use itertools::Itertools;
+use liwe::model::node::Node;
 use liwe::{
     graph::{DatabaseContext, Graph, GraphContext},
     model::{
@@ -13,7 +13,7 @@ use liwe::{
 };
 use lsp_server::ResponseError;
 use lsp_types::*;
-use liwe::model::node::Node;
+use std::time::SystemTime;
 
 use super::{LspClient, ServerConfig};
 
@@ -47,7 +47,11 @@ impl Server {
             &config.state,
             config.sequential_ids.unwrap_or(false),
             config.configuration.markdown.clone(),
-            config.configuration.library.frontmatter_document_title.clone(),
+            config
+                .configuration
+                .library
+                .frontmatter_document_title
+                .clone(),
         );
         let mut search_index = SearchIndex::new();
         search_index.update(&graph);
@@ -86,7 +90,7 @@ impl Server {
             return None;
         }
 
-        let target_key = Key::from_rel_link_url(url, &relative_to);
+        let target_key = self.resolve_reference_key(url, &relative_to);
         let markdown = self.graph.to_markdown_skip_frontmatter(&target_key);
 
         if markdown.trim().is_empty() {
@@ -198,8 +202,8 @@ impl Server {
                     _ => 0,
                 };
                 let word_start_byte = cursor_byte - word.len();
-                let word_start_char = byte_to_utf16_offset(line, word_start_byte)
-                    .unwrap_or(position.character);
+                let word_start_char =
+                    byte_to_utf16_offset(line, word_start_byte).unwrap_or(position.character);
                 Some((bracket.to_string(), query.len(), word_start_char, trailing))
             })
             .unwrap_or((String::new(), 0, position.character, 0));
@@ -263,8 +267,10 @@ impl Server {
             return DefinitionResult::External(url);
         }
 
+        let target_key = self.resolve_reference_key(&url, &relative_to);
+
         DefinitionResult::Internal(GotoDefinitionResponse::Scalar(Location::new(
-            self.base_path.resolve_relative_url(&url, &relative_to),
+            self.base_path.key_to_url(&target_key),
             Range::default(),
         )))
     }
@@ -439,7 +445,7 @@ impl Server {
                         .to_key(&self.base_path),
                 )
                 .and_then(|parser| parser.url_at(params.text_document_position.position.to_model()))
-                .map(|url| Key::from_rel_link_url(&url, relative_to))
+                .map(|url| self.resolve_reference_key(&url, relative_to))
                 .filter(|key| query::key_exists(&self.graph, key))
                 .map(|key| {
                     let affected_keys = query::all_backlinks(&self.graph, &key)
@@ -529,7 +535,7 @@ impl Server {
                     .to_key(&self.base_path),
             )
             .and_then(|parser| parser.url_at(params.text_document_position.position.to_model()))
-            .map(|url| Key::from_rel_link_url(&url, relative_to))
+            .map(|url| self.resolve_reference_key(&url, relative_to))
             .unwrap_or(key.clone());
 
         self.graph
@@ -609,11 +615,7 @@ impl Server {
             return code_action.clone();
         };
 
-        let Some(key) = data
-            .get("key")
-            .and_then(|v| v.as_str())
-            .map(Key::name)
-        else {
+        let Some(key) = data.get("key").and_then(|v| v.as_str()).map(Key::name) else {
             return code_action.clone();
         };
 
@@ -679,11 +681,7 @@ impl Server {
     pub fn handle_folding_range(&self, params: FoldingRangeParams) -> Vec<FoldingRange> {
         let key = params.text_document.uri.to_key(&self.base_path);
 
-        let Some(tree) = self
-            .graph
-            .maybe_key(&key)
-            .map(|p| p.collect_tree())
-        else {
+        let Some(tree) = self.graph.maybe_key(&key).map(|p| p.collect_tree()) else {
             return vec![];
         };
 
@@ -702,7 +700,10 @@ impl Server {
                         let header_prefix = "#".repeat(level as usize);
                         let text: String = inlines.iter().map(|i| i.plain_text()).collect();
                         next_level = level + 1;
-                        (Some((end - 1) as u32), Some(format!("{} {}", header_prefix, text)))
+                        (
+                            Some((end - 1) as u32),
+                            Some(format!("{} {}", header_prefix, text)),
+                        )
                     }
                     Node::Raw(lang, _) if line_range.end > line_range.start + 1 => {
                         (Some((line_range.end - 1) as u32), lang.clone())
@@ -763,7 +764,10 @@ impl Server {
     }
 
     fn max_end_line_recursive(&self, tree: &Tree) -> Option<usize> {
-        let own_end = tree.id.and_then(|id| self.graph.node_line_range(id)).map(|r| r.end);
+        let own_end = tree
+            .id
+            .and_then(|id| self.graph.node_line_range(id))
+            .map(|r| r.end);
         let children_max = tree
             .children
             .iter()
@@ -774,6 +778,27 @@ impl Server {
             (Some(a), None) => Some(a),
             (None, Some(b)) => Some(b),
             (None, None) => None,
+        }
+    }
+
+    fn resolve_reference_key(&self, url: &str, relative_to: &str) -> Key {
+        let direct = Key::from_rel_link_url(url, relative_to);
+        if query::key_exists(&self.graph, &direct) {
+            return direct;
+        }
+
+        // Fallback for wiki links that omit directories: use a unique basename match.
+        let direct_name = direct.source();
+        let candidates = query::all_keys(&self.graph)
+            .into_iter()
+            .map(|m| m.key)
+            .filter(|k| k.source() == direct_name)
+            .collect_vec();
+
+        if candidates.len() == 1 {
+            candidates[0].clone()
+        } else {
+            direct
         }
     }
 }
@@ -845,27 +870,21 @@ impl ActionContext for &Server {
 
     fn get_link_key_at(&self, key: &Key, line: usize, character: usize) -> Option<Key> {
         let parser = self.graph().parser(key)?;
-        let position = liwe::model::Position {
-            line,
-            character,
-        };
+        let position = liwe::model::Position { line, character };
         let url = parser.url_at(position)?;
 
         if !is_ref_url(&url) {
             return None;
         }
 
-        let target_key = Key::from_rel_link_url(&url, &key.parent());
+        let target_key = self.resolve_reference_key(&url, &key.parent());
         self.graph.maybe_key(&target_key)?;
         Some(target_key)
     }
 
     fn get_link_text_at(&self, key: &Key, line: usize, character: usize) -> Option<String> {
         let parser = self.graph().parser(key)?;
-        let position = liwe::model::Position {
-            line,
-            character,
-        };
+        let position = liwe::model::Position { line, character };
         let link = parser.link_at(position)?;
         Some(link.to_plain_text())
     }

--- a/crates/iwes/src/router/server/base_path.rs
+++ b/crates/iwes/src/router/server/base_path.rs
@@ -20,7 +20,9 @@ impl BasePath {
     }
 
     pub fn from_path(path: &str) -> Self {
-        let url = Url::from_directory_path(path).expect("valid base path");
+        let url = Url::from_directory_path(path)
+            .or_else(|_| file_url_from_posix_path(path))
+            .expect("valid base path");
         Self {
             url: canonical(url),
         }
@@ -40,18 +42,23 @@ impl BasePath {
 
     pub fn url_to_key(&self, uri: &Uri) -> Key {
         let url = canonical(Url::parse(&uri.to_string()).expect("valid URI"));
-        let base = self.url.to_file_path().expect("base is a file URL");
-        let target = url.to_file_path().expect("URI is a file URL");
-        let relative = target.strip_prefix(&base).unwrap_or(&target);
-
-        let joined = relative
-            .components()
-            .filter_map(|c| match c {
-                std::path::Component::Normal(os) => Some(os.to_string_lossy().to_string()),
-                _ => None,
-            })
-            .collect::<Vec<_>>()
-            .join("/");
+        let base = normalize_windows_drive_segment(
+            self.url
+                .path_segments()
+                .expect("base is a file URL")
+                .filter(|segment| !segment.is_empty())
+                .map(|segment| percent_decode_str(segment).decode_utf8_lossy().into_owned())
+                .collect::<Vec<_>>(),
+        );
+        let target = normalize_windows_drive_segment(
+            url.path_segments()
+                .expect("URI is a file URL")
+                .filter(|segment| !segment.is_empty())
+                .map(|segment| percent_decode_str(segment).decode_utf8_lossy().into_owned())
+                .collect::<Vec<_>>(),
+        );
+        let relative = target.strip_prefix(base.as_slice()).unwrap_or(&target);
+        let joined = relative.join("/");
 
         Key::name(&joined)
     }
@@ -69,7 +76,10 @@ impl BasePath {
 
         let mut resolved = source.join(link).expect("valid link");
 
-        let last = resolved.path_segments().and_then(|s| s.last()).unwrap_or("");
+        let last = resolved
+            .path_segments()
+            .and_then(|s| s.last())
+            .unwrap_or("");
         if !last.is_empty() && !last.ends_with(".md") {
             let decoded = percent_decode_str(last).decode_utf8_lossy().into_owned();
             resolved
@@ -98,6 +108,22 @@ impl BasePath {
     }
 }
 
+fn file_url_from_posix_path(path: &str) -> Result<Url, ()> {
+    if !path.starts_with('/') {
+        return Err(());
+    }
+
+    let mut url = Url::parse("file:///").map_err(|_| ())?;
+    {
+        let mut segments = url.path_segments_mut().map_err(|_| ())?;
+        for segment in path.split('/').filter(|s| !s.is_empty()) {
+            segments.push(segment);
+        }
+        segments.push("");
+    }
+    Ok(url)
+}
+
 fn canonical(url: Url) -> Url {
     if url.scheme() != "file" {
         return url;
@@ -120,13 +146,25 @@ fn lowercase_drive_letter(path: &Path) -> PathBuf {
     let (prefix, rest) = s.strip_prefix('/').map_or(("", s.as_ref()), |r| ("/", r));
     let mut chars = rest.chars();
     match (chars.next(), chars.next()) {
-        (Some(d), Some(':')) if d.is_ascii_alphabetic() => {
-            PathBuf::from(format!("{}{}{}", prefix, d.to_ascii_lowercase(), &rest[2..]))
-        }
+        (Some(d), Some(':')) if d.is_ascii_alphabetic() => PathBuf::from(format!(
+            "{}{}{}",
+            prefix,
+            d.to_ascii_lowercase(),
+            &rest[2..]
+        )),
         _ => path.to_path_buf(),
     }
 }
 
+fn normalize_windows_drive_segment(mut segments: Vec<String>) -> Vec<String> {
+    if let Some(first) = segments.first_mut() {
+        let bytes = first.as_bytes();
+        if bytes.len() == 2 && bytes[1] == b':' && bytes[0].is_ascii_alphabetic() {
+            first.make_ascii_lowercase();
+        }
+    }
+    segments
+}
 
 #[cfg(test)]
 mod tests {
@@ -162,10 +200,7 @@ mod tests {
         let base_path = BasePath::from_path("/path with spaces/docs");
         let key = liwe::model::Key::name("test.md");
         let url = base_path.key_to_url(&key);
-        assert_eq!(
-            url.to_string(),
-            "file:///path%20with%20spaces/docs/test.md"
-        );
+        assert_eq!(url.to_string(), "file:///path%20with%20spaces/docs/test.md");
     }
 
     #[test]
@@ -177,14 +212,19 @@ mod tests {
     }
 
     #[test]
+    fn test_url_to_key_with_nested_windows_path_uses_forward_slashes() {
+        let base_path = BasePath::new("file:///C:/base/".to_string());
+        let uri = Uri::from_str("file:///c%3A/base/sub/dir/note.md").unwrap();
+        let key = base_path.url_to_key(&uri);
+        assert_eq!(key.to_string(), "sub/dir/note");
+    }
+
+    #[test]
     fn test_key_to_url_with_spaces_in_key() {
         let base_path = BasePath::from_path("/basepath");
         let key = liwe::model::Key::name("my document.md");
         let url = base_path.key_to_url(&key);
-        assert_eq!(
-            url.to_string(),
-            "file:///basepath/my%20document.md"
-        );
+        assert_eq!(url.to_string(), "file:///basepath/my%20document.md");
     }
 
     #[test]
@@ -232,8 +272,7 @@ mod tests {
         let source_key = base_path.url_to_key(&source_uri);
         let target_key = base_path.url_to_key(&target_uri);
 
-        let parsed_target_key =
-            liwe::model::Key::from_rel_link_url("two", &source_key.parent());
+        let parsed_target_key = liwe::model::Key::from_rel_link_url("two", &source_key.parent());
 
         assert_eq!(parsed_target_key.to_string(), target_key.to_string());
     }

--- a/crates/iwes/src/router/server/extensions.rs
+++ b/crates/iwes/src/router/server/extensions.rs
@@ -149,6 +149,30 @@ pub fn byte_to_utf16_offset(line: &str, byte_offset: usize) -> Option<u32> {
     (byte_offset == line.len()).then_some(units)
 }
 
+#[cfg(test)]
+mod tests {
+    use liwe::{markdown::MarkdownReader, model::config::MarkdownOptions, parser::Parser};
+
+    use super::*;
+
+    #[test]
+    fn utf16_position_after_cjk_text_does_not_match_parser_byte_offsets() {
+        let line = "新西兰旅行，四月最后一个周末。[[travel-2025-beijing]]";
+        let parser = Parser::new(line, &MarkdownOptions::default(), MarkdownReader::new());
+
+        // LSP sends UTF-16 code units. The first `[` is at UTF-16 column 19 on this line.
+        let lsp_column = 19;
+        assert_eq!(utf16_to_byte_offset(line, lsp_column), Some(49));
+
+        // Current hover/definition code uses `position.to_model()` directly,
+        // so it passes 19 as the internal column and misses the wiki link.
+        assert_eq!(
+            parser.url_at(Position::new(0, lsp_column).to_model()),
+            Some("travel-2025-beijing".to_string())
+        );
+    }
+}
+
 pub struct LinkCompletionContext {
     pub bracket_prefix: String,
     pub replace_range: Range,

--- a/crates/iwes/tests/go_to_definition_test.rs
+++ b/crates/iwes/tests/go_to_definition_test.rs
@@ -4,6 +4,14 @@ use std::str::FromStr;
 
 use crate::fixture::*;
 
+fn utf16_offset_of(text: &str, needle: &str) -> u32 {
+    let byte_offset = text.find(needle).expect("needle to exist");
+    text[..byte_offset]
+        .chars()
+        .map(|ch| ch.len_utf16() as u32)
+        .sum()
+}
+
 #[test]
 fn no_definition() {
     Fixture::new().go_to_definition(
@@ -66,6 +74,68 @@ fn definition_in_paragraph_wiki_link() {
         uri(1).to_goto_definition_params(2, 17),
         goto_definition_response_empty(),
     );
+}
+
+#[test]
+fn definition_in_paragraph_wiki_link_after_cjk_text() {
+    Fixture::with(indoc! {"
+            # test
+
+            新西兰旅行，四月最后一个周末。[[travel-2025-beijing]]
+
+            "})
+    .go_to_definition(
+        uri(1).to_goto_definition_params(2, 19),
+        goto_definition_response_single(
+            lsp_types::Uri::from_str("file:///basepath/travel-2025-beijing.md").unwrap(),
+        ),
+    );
+}
+
+#[test]
+fn definition_in_paragraph_wiki_link_after_emoji_text() {
+    Fixture::with(indoc! {"
+            # test
+
+            Plan 🧭 [[travel-2025-beijing]]
+
+            "})
+    .go_to_definition(
+        uri(1).to_goto_definition_params(2, 8),
+        goto_definition_response_single(
+            lsp_types::Uri::from_str("file:///basepath/travel-2025-beijing.md").unwrap(),
+        ),
+    );
+}
+
+#[test]
+fn definition_for_wiki_links_inside_table_rows() {
+    let line = "| 日 | [[2026-05-23]] | [[2026-05-25]] |";
+    let state = std::collections::HashMap::from([
+        ("source".to_string(), format!("# diary\n\n{}\n", line)),
+        (
+            "2026-05-23".to_string(),
+            "# 2026-05-23\nPast day\n".to_string(),
+        ),
+        (
+            "2026-05-25".to_string(),
+            "# 2026-05-25\nFuture day\n".to_string(),
+        ),
+    ]);
+
+    Fixture::with_options_and_client(state, Default::default(), "", None)
+        .go_to_definition(
+            uri_from("source").to_goto_definition_params(2, 8),
+            goto_definition_response_single(
+                lsp_types::Uri::from_str("file:///basepath/2026-05-23.md").unwrap(),
+            ),
+        )
+        .go_to_definition(
+            uri_from("source").to_goto_definition_params(2, 25),
+            goto_definition_response_single(
+                lsp_types::Uri::from_str("file:///basepath/2026-05-25.md").unwrap(),
+            ),
+        );
 }
 
 #[test]
@@ -196,10 +266,7 @@ fn definition_external_http_url() {
             [example](http://example.com)
 
             "})
-    .go_to_definition_external(
-        uri(1).to_goto_definition_params(2, 5),
-        "http://example.com",
-    );
+    .go_to_definition_external(uri(1).to_goto_definition_params(2, 5), "http://example.com");
 }
 
 #[test]
@@ -256,4 +323,29 @@ fn definition_bare_mailto_url() {
         uri(1).to_goto_definition_params(2, 15),
         "mailto:test@example.com",
     );
+}
+
+#[test]
+fn definition_with_complex_unicode_mixed_line_multiple_wiki_links() {
+    let line = "\"新西兰旅行🗺️，四月最后一个周末（2025-04-26～2025-04-27）｜天气：12°C～18°C，风速≈7㎧；预算 NZ$2,888.50；同行者：张三／Alice／λ-user。备注：试试 Māori 美食、温泉♨️、观星🌌；关键词：CJK混排「漢字かなカナ한글」，Unicode：Ω≈ç√∫˜µ≤≥÷，数学：∀x∈ℝ,f(x)=x²→∞，Emoji：👨🏽‍💻🧋🐑🇳🇿，全角／半角：ＡBC123；引用：『人生は旅である』；路径：C:\\旅程\\NZ\\照片📷\\；标签：#旅行 #测试 [[travel-2025-beijing]] [[北京-旅行🧳]]\"";
+    let state =
+        std::collections::HashMap::from([("1".to_string(), format!("# test\n\n{}\n", line))]);
+
+    Fixture::with_options_and_client(state, Default::default(), "", None)
+        .go_to_definition(
+            uri(1)
+                .to_goto_definition_params(2, utf16_offset_of(line, "[[travel-2025-beijing]]") + 2),
+            goto_definition_response_single(
+                lsp_types::Uri::from_str("file:///basepath/travel-2025-beijing.md").unwrap(),
+            ),
+        )
+        .go_to_definition(
+            uri(1).to_goto_definition_params(2, utf16_offset_of(line, "[[北京 - 旅行🧳]]") + 2),
+            goto_definition_response_single(
+                lsp_types::Uri::from_str(
+                    "file:///basepath/%E5%8C%97%E4%BA%AC-%E6%97%85%E8%A1%8C%F0%9F%A7%B3.md",
+                )
+                .unwrap(),
+            ),
+        );
 }

--- a/crates/iwes/tests/hover_test.rs
+++ b/crates/iwes/tests/hover_test.rs
@@ -4,6 +4,14 @@ use std::collections::HashMap;
 
 use crate::fixture::*;
 
+fn utf16_offset_of(text: &str, needle: &str) -> u32 {
+    let byte_offset = text.find(needle).expect("needle to exist");
+    text[..byte_offset]
+        .chars()
+        .map(|ch| ch.len_utf16() as u32)
+        .sum()
+}
+
 #[test]
 fn hover_preview_for_wiki_link_strips_frontmatter() {
     Fixture::with_documents(vec![
@@ -70,6 +78,131 @@ fn hover_preview_for_markdown_link() {
 }
 
 #[test]
+fn hover_preview_for_wiki_link_after_cjk_text() {
+    let state = HashMap::from([
+        (
+            "1".to_string(),
+            "新西兰旅行，四月最后一个周末。[[travel-2025-beijing]]".to_string(),
+        ),
+        (
+            "travel-2025-beijing".to_string(),
+            indoc! {"
+                # Beijing
+                Trip plan
+            "}
+            .to_string(),
+        ),
+    ]);
+
+    Fixture::with_options_and_client(state, Default::default(), "", None)
+        .assert_response::<HoverRequest>(
+            uri(1).to_hover_params(0, 19),
+            Some(Hover {
+                contents: HoverContents::Markup(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value: "# Beijing\n\nTrip plan\n".to_string(),
+                }),
+                range: None,
+            }),
+        );
+}
+
+#[test]
+fn hover_preview_for_wiki_link_after_emoji_text() {
+    let state = HashMap::from([
+        (
+            "1".to_string(),
+            "Plan 🧭 [[travel-2025-beijing]]".to_string(),
+        ),
+        (
+            "travel-2025-beijing".to_string(),
+            indoc! {"
+                # Beijing
+                Trip plan
+            "}
+            .to_string(),
+        ),
+    ]);
+
+    Fixture::with_options_and_client(state, Default::default(), "", None)
+        .assert_response::<HoverRequest>(
+            uri(1).to_hover_params(0, 8),
+            Some(Hover {
+                contents: HoverContents::Markup(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value: "# Beijing\n\nTrip plan\n".to_string(),
+                }),
+                range: None,
+            }),
+        );
+}
+
+#[test]
+fn hover_preview_for_wiki_links_inside_table_rows() {
+    let line = "| 日 | [[2026-05-23]] | [[2026-05-25]] |";
+    let state = HashMap::from([
+        ("source".to_string(), format!("# diary\n\n{}\n", line)),
+        (
+            "2026-05-23".to_string(),
+            "# 2026-05-23\nPast day\n".to_string(),
+        ),
+        (
+            "2026-05-25".to_string(),
+            "# 2026-05-25\nFuture day\n".to_string(),
+        ),
+    ]);
+
+    let fixture = Fixture::with_options_and_client(state, Default::default(), "", None);
+
+    fixture.assert_response::<HoverRequest>(
+        uri_from("source").to_hover_params(2, utf16_offset_of(line, "[[2026-05-23]]") + 2),
+        Some(Hover {
+            contents: HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: "# 2026-05-23\n\nPast day\n".to_string(),
+            }),
+            range: None,
+        }),
+    );
+    fixture.assert_response::<HoverRequest>(
+        uri_from("source").to_hover_params(2, utf16_offset_of(line, "[[2026-05-25]]") + 2),
+        Some(Hover {
+            contents: HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: "# 2026-05-25\n\nFuture day\n".to_string(),
+            }),
+            range: None,
+        }),
+    );
+}
+
+#[test]
+fn hover_preview_falls_back_to_unique_basename_key() {
+    let state = HashMap::from([
+        (
+            "journal/day-1".to_string(),
+            "text [[cxx陈小欣]] text".to_string(),
+        ),
+        (
+            "01_Diary/01.01_People/cxx陈小欣".to_string(),
+            "# Person\nKnown from notes\n".to_string(),
+        ),
+    ]);
+
+    Fixture::with_options_and_client(state, Default::default(), "", None)
+        .assert_response::<HoverRequest>(
+            uri_from("journal/day-1").to_hover_params(0, 7),
+            Some(Hover {
+                contents: HoverContents::Markup(MarkupContent {
+                    kind: MarkupKind::Markdown,
+                    value: "# Person\n\nKnown from notes\n".to_string(),
+                }),
+                range: None,
+            }),
+        );
+}
+
+#[test]
 fn hover_outside_link_returns_none() {
     Fixture::with_documents(vec![("1", "no links here\n"), ("2", "# Heading\n")])
         .assert_response::<HoverRequest>(uri(1).to_hover_params(0, 0), None);
@@ -79,4 +212,54 @@ fn hover_outside_link_returns_none() {
 fn hover_missing_target_returns_none() {
     Fixture::with_documents(vec![("1", "text [[missing]] text\n")])
         .assert_response::<HoverRequest>(uri(1).to_hover_params(0, 7), None);
+}
+
+#[test]
+fn hover_preview_for_complex_unicode_mixed_line_multiple_wiki_links() {
+    let line = "\"新西兰旅行🗺️，四月最后一个周末（2025-04-26～2025-04-27）｜天气：12°C～18°C，风速≈7㎧；预算 NZ$2,888.50；同行者：张三／Alice／λ-user。备注：试试 Māori 美食、温泉♨️、观星🌌；关键词：CJK混排「漢字かなカナ한글」，Unicode：Ω≈ç√∫˜µ≤≥÷，数学：∀x∈ℝ,f(x)=x²→∞，Emoji：👨🏽‍💻🧋🐑🇳🇿，全角／半角：ＡBC123；引用：『人生は旅である』；路径：C:\\旅程\\NZ\\照片📷\\；标签：#旅行 #测试 [[travel-2025-beijing]] [[北京-旅行🧳]] [[旅行/2025/新西兰🇳🇿]]\"";
+    let state = HashMap::from([
+        ("1".to_string(), line.to_string()),
+        (
+            "travel-2025-beijing".to_string(),
+            "# Beijing\nTrip plan\n".to_string(),
+        ),
+        ("北京-旅行🧳".to_string(), "# 北京\n行程草案\n".to_string()),
+        (
+            "旅行/2025/新西兰🇳🇿".to_string(),
+            "# 新西兰\n银河与温泉\n".to_string(),
+        ),
+    ]);
+
+    let fixture = Fixture::with_options_and_client(state, Default::default(), "", None);
+
+    fixture.assert_response::<HoverRequest>(
+        uri(1).to_hover_params(0, utf16_offset_of(line, "[[travel-2025-beijing]]") + 2),
+        Some(Hover {
+            contents: HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: "# Beijing\n\nTrip plan\n".to_string(),
+            }),
+            range: None,
+        }),
+    );
+    fixture.assert_response::<HoverRequest>(
+        uri(1).to_hover_params(0, utf16_offset_of(line, "[[北京-旅行🧳]]") + 2),
+        Some(Hover {
+            contents: HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: "# 北京\n\n行程草案\n".to_string(),
+            }),
+            range: None,
+        }),
+    );
+    fixture.assert_response::<HoverRequest>(
+        uri(1).to_hover_params(0, utf16_offset_of(line, "[[旅行/2025/新西兰🇳🇿]]") + 2),
+        Some(Hover {
+            contents: HoverContents::Markup(MarkupContent {
+                kind: MarkupKind::Markdown,
+                value: "# 新西兰\n\n银河与温泉\n".to_string(),
+            }),
+            range: None,
+        }),
+    );
 }

--- a/crates/iwes/tests/main.rs
+++ b/crates/iwes/tests/main.rs
@@ -24,3 +24,6 @@ mod sections_to_list_test;
 mod sort_test;
 mod transform_test;
 mod workspace_symbols_test;
+
+#[cfg(windows)]
+mod windows_real_workspace_test;

--- a/crates/iwes/tests/references_test.rs
+++ b/crates/iwes/tests/references_test.rs
@@ -2,6 +2,14 @@ use indoc::indoc;
 
 use crate::fixture::*;
 
+fn utf16_offset_of(text: &str, needle: &str) -> u32 {
+    let byte_offset = text.find(needle).expect("needle to exist");
+    text[..byte_offset]
+        .chars()
+        .map(|ch| ch.len_utf16() as u32)
+        .sum()
+}
+
 #[test]
 fn single_reference() {
     Fixture::with(indoc! {"
@@ -54,4 +62,108 @@ fn link() {
         # target
         "})
     .references(uri(1).to_reference_params(2, 15, false), vec![]);
+}
+
+#[test]
+fn wiki_link_after_cjk_text() {
+    Fixture::with(indoc! {"
+        # doc1
+
+        新西兰旅行，四月最后一个周末。[[3]]
+        _
+        # doc2
+
+        [target](3)
+        _
+        # target
+        "})
+    .references(
+        uri(1).to_reference_params(2, 19, false),
+        vec![uri(2).to_location(2, 3)],
+    );
+}
+
+#[test]
+fn wiki_link_after_emoji_text() {
+    Fixture::with(indoc! {"
+        # doc1
+
+        Plan 🧭 [[3]]
+        _
+        # doc2
+
+        [target](3)
+        _
+        # target
+        "})
+    .references(
+        uri(1).to_reference_params(2, 8, false),
+        vec![uri(2).to_location(2, 3)],
+    );
+}
+
+#[test]
+fn wiki_links_inside_table_rows() {
+    let line = "| 日 | [[2026-05-23]] | [[2026-05-25]] |";
+    let state = std::collections::HashMap::from([
+        ("source-1".to_string(), format!("# diary\n\n{}\n", line)),
+        ("source-2".to_string(), format!("# diary\n\n{}\n", line)),
+        (
+            "2026-05-23".to_string(),
+            "# 2026-05-23\nPast day\n".to_string(),
+        ),
+        (
+            "2026-05-25".to_string(),
+            "# 2026-05-25\nFuture day\n".to_string(),
+        ),
+    ]);
+
+    Fixture::with_options_and_client(state, Default::default(), "", None)
+        .references(
+            uri_from("source-1").to_reference_params(2, 8, false),
+            vec![],
+        )
+        .references(
+            uri_from("source-1").to_reference_params(2, 25, false),
+            vec![],
+        );
+}
+
+#[test]
+fn wiki_links_inside_complex_unicode_mixed_line() {
+    let line = "\"新西兰旅行🗺️，四月最后一个周末（2025-04-26～2025-04-27）｜天气：12°C～18°C，风速≈7㎧；预算 NZ$2,888.50；同行者：张三／Alice／λ-user。备注：试试 Māori 美食、温泉♨️、观星🌌；关键词：CJK混排「漢字かなカナ한글」，Unicode：Ω≈ç√∫˜µ≤≥÷，数学：∀x∈ℝ,f(x)=x²→∞，Emoji：👨🏽‍💻🧋🐑🇳🇿，全角／半角：ＡBC123；引用：『人生は旅である』；路径：C:\\旅程\\NZ\\照片📷\\；标签：#旅行 #测试 [[travel-2025-beijing]] [[北京-旅行🧳]] [[旅行/2025/新西兰🇳🇿]]\"";
+    let state = std::collections::HashMap::from([
+        ("1".to_string(), format!("# doc1\n\n{}\n", line)),
+        (
+            "2".to_string(),
+            "[target](travel-2025-beijing)\n".to_string(),
+        ),
+        ("3".to_string(), "[target](北京-旅行🧳)\n".to_string()),
+        (
+            "4".to_string(),
+            "[target](旅行/2025/新西兰🇳🇿)\n".to_string(),
+        ),
+    ]);
+
+    Fixture::with_options_and_client(state, Default::default(), "", None)
+        .references(
+            uri(1).to_reference_params(
+                2,
+                utf16_offset_of(line, "[[travel-2025-beijing]]") + 2,
+                false,
+            ),
+            vec![uri(2).to_location(0, 1)],
+        )
+        .references(
+            uri(1).to_reference_params(2, utf16_offset_of(line, "[[北京-旅行🧳]]") + 2, false),
+            vec![uri(3).to_location(0, 1)],
+        )
+        .references(
+            uri(1).to_reference_params(
+                2,
+                utf16_offset_of(line, "[[旅行/2025/新西兰🇳🇿]]") + 2,
+                false,
+            ),
+            vec![uri(4).to_location(0, 1)],
+        );
 }

--- a/crates/iwes/tests/windows_real_workspace_test.rs
+++ b/crates/iwes/tests/windows_real_workspace_test.rs
@@ -1,0 +1,268 @@
+#![cfg(windows)]
+
+use std::{
+    env,
+    io::{BufRead, BufReader, Read, Write},
+    path::{Path, PathBuf},
+    process::{ChildStdin, ChildStdout, Command, Stdio},
+};
+
+use serde_json::{json, Value};
+use url::Url;
+
+#[test]
+fn real_workspace_hover_definition_and_inlay_hint_are_visible() {
+    let root = Path::new(r"D:\Twy59sGthb\new_notes");
+    let temp_workspace = tempfile::Builder::new()
+        .prefix("windows-repro-")
+        .tempdir_in(root)
+        .expect("create temp workspace");
+    let temp_root = temp_workspace.path().to_path_buf();
+    let nested_dir = temp_root.join("nested");
+    let source_doc = temp_root.join("source.md");
+    let target_doc = nested_dir.join("target.md");
+    let source_text = "计划 🧭 [[nested/target]]";
+    let target_text = "# target\n\nrepro";
+
+    assert!(root.exists(), "missing test workspace: {root:?}");
+    std::fs::create_dir_all(&nested_dir).expect("create nested dir");
+    std::fs::write(&source_doc, source_text).expect("write source doc");
+    std::fs::write(&target_doc, target_text).expect("write target doc");
+
+    let (line, character) = link_position(source_text, "[[nested/target]]");
+    let doc_uri = Url::from_file_path(&source_doc)
+        .expect("document uri")
+        .to_string();
+    let target_uri = Url::from_file_path(&target_doc)
+        .expect("target uri")
+        .to_string();
+    let root_uri = Url::from_directory_path(root)
+        .expect("workspace uri")
+        .to_string();
+
+    let binary = binary_path();
+    let mut process = Command::new(&binary)
+        .current_dir(root)
+        .env("IWE_DEBUG", "1")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+        .unwrap_or_else(|error| panic!("spawn {binary:?}: {error}"));
+
+    let mut stdin = process.stdin.take().expect("child stdin");
+    let stdout = process.stdout.take().expect("child stdout");
+    let mut stdout = BufReader::new(stdout);
+
+    let mut next_id = 1_i32;
+    let initialize_id = next_request_id(&mut next_id);
+    send(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": initialize_id,
+            "method": "initialize",
+            "params": {
+                "processId": std::process::id(),
+                "rootUri": root_uri,
+                "workspaceFolders": [{"uri": root_uri, "name": "new_notes"}],
+                "capabilities": {},
+                "clientInfo": {"name": "windows-repro-test", "version": "1.0"}
+            }
+        }),
+    );
+    let initialize_resp = wait_for_response(&mut stdout, initialize_id);
+    assert!(
+        initialize_resp.get("error").is_none(),
+        "initialize failed: {initialize_resp}"
+    );
+
+    send(
+        &mut stdin,
+        &json!({"jsonrpc": "2.0", "method": "initialized", "params": {}}),
+    );
+    send(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "method": "textDocument/didOpen",
+            "params": {
+                "textDocument": {
+                    "uri": doc_uri,
+                    "languageId": "markdown",
+                    "version": 1,
+                    "text": source_text,
+                }
+            }
+        }),
+    );
+
+    let hover_id = next_request_id(&mut next_id);
+    send(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": hover_id,
+            "method": "textDocument/hover",
+            "params": {
+                "textDocument": {"uri": doc_uri},
+                "position": {"line": line, "character": character}
+            }
+        }),
+    );
+
+    let definition_id = next_request_id(&mut next_id);
+    send(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": definition_id,
+            "method": "textDocument/definition",
+            "params": {
+                "textDocument": {"uri": doc_uri},
+                "position": {"line": line, "character": character}
+            }
+        }),
+    );
+
+    let inlay_id = next_request_id(&mut next_id);
+    send(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": inlay_id,
+            "method": "textDocument/inlayHint",
+            "params": {
+                "textDocument": {"uri": target_uri},
+                "range": {
+                    "start": {"line": 0, "character": 0},
+                    "end": {"line": target_text.lines().count(), "character": 0}
+                }
+            }
+        }),
+    );
+
+    let hover_resp = wait_for_response(&mut stdout, hover_id);
+    let definition_resp = wait_for_response(&mut stdout, definition_id);
+    let inlay_resp = wait_for_response(&mut stdout, inlay_id);
+
+    let hover_result = hover_resp.get("result").expect("hover result missing");
+    assert!(!hover_result.is_null(), "hover returned null: {hover_resp}");
+
+    let definition_result = definition_resp
+        .get("result")
+        .expect("definition result missing");
+    assert!(
+        match definition_result {
+            Value::Object(_) => true,
+            Value::Array(items) => !items.is_empty(),
+            _ => false,
+        },
+        "definition returned empty: {definition_resp}"
+    );
+
+    let inlay_result = inlay_resp
+        .get("result")
+        .and_then(Value::as_array)
+        .expect("inlay hint result missing");
+    assert!(
+        !inlay_result.is_empty(),
+        "inlay hints returned empty: {inlay_resp}"
+    );
+
+    let shutdown_id = next_request_id(&mut next_id);
+    send(
+        &mut stdin,
+        &json!({
+            "jsonrpc": "2.0",
+            "id": shutdown_id,
+            "method": "shutdown",
+            "params": {}
+        }),
+    );
+    let _ = wait_for_response(&mut stdout, shutdown_id);
+    send(
+        &mut stdin,
+        &json!({"jsonrpc": "2.0", "method": "exit", "params": {}}),
+    );
+
+    let _ = process.wait();
+}
+
+fn next_request_id(next_id: &mut i32) -> i32 {
+    let id = *next_id;
+    *next_id += 1;
+    id
+}
+
+fn send(stdin: &mut ChildStdin, message: &Value) {
+    let payload = serde_json::to_vec(message).expect("serialize json-rpc message");
+    let header = format!("Content-Length: {}\r\n\r\n", payload.len());
+    stdin.write_all(header.as_bytes()).expect("write header");
+    stdin.write_all(&payload).expect("write body");
+    stdin.flush().expect("flush message");
+}
+
+fn wait_for_response(stdout: &mut BufReader<ChildStdout>, id: i32) -> Value {
+    loop {
+        let message = read_message(stdout);
+        if message.get("id").and_then(Value::as_i64) == Some(id as i64) {
+            return message;
+        }
+    }
+}
+
+fn read_message(stdout: &mut BufReader<ChildStdout>) -> Value {
+    let mut content_length = None;
+    let mut line = String::new();
+
+    loop {
+        line.clear();
+        stdout.read_line(&mut line).expect("read header line");
+        if line.is_empty() {
+            panic!("unexpected EOF while reading LSP headers");
+        }
+
+        let trimmed = line.trim_end_matches(['\r', '\n']);
+        if trimmed.is_empty() {
+            break;
+        }
+
+        if let Some(value) = trimmed.strip_prefix("Content-Length:") {
+            content_length = Some(value.trim().parse::<usize>().expect("parse content length"));
+        }
+    }
+
+    let mut body = vec![0_u8; content_length.expect("missing Content-Length")];
+    stdout.read_exact(&mut body).expect("read LSP body");
+    serde_json::from_slice(&body).expect("parse LSP message")
+}
+
+fn link_position(text: &str, needle: &str) -> (u32, u32) {
+    for (line_index, line) in text.lines().enumerate() {
+        if let Some(byte_offset) = line.find(needle) {
+            let character = line[..byte_offset]
+                .chars()
+                .map(|ch| ch.len_utf16() as u32)
+                .sum::<u32>()
+                + 2;
+            return (line_index as u32, character);
+        }
+    }
+
+    panic!("needle not found: {needle}");
+}
+
+fn binary_path() -> PathBuf {
+    if let Ok(path) = env::var("CARGO_BIN_EXE_iwes") {
+        return PathBuf::from(path);
+    }
+
+    let current_exe = env::current_exe().expect("current exe");
+    let target_dir = current_exe
+        .parent()
+        .and_then(Path::parent)
+        .expect("test exe parent")
+        .to_path_buf();
+    target_dir.join("iwes.exe")
+}

--- a/crates/liwe/src/fs.rs
+++ b/crates/liwe/src/fs.rs
@@ -46,15 +46,7 @@ pub fn walk_md_paths(base_path: &Path) -> Vec<(String, PathBuf)> {
             }
 
             let relative_path = path.strip_prefix(base_path).ok()?;
-            let key = if let Some(parent) = relative_path.parent() {
-                if parent == std::path::Path::new("") {
-                    to_file_name(path)
-                } else {
-                    format!("{}/{}", parent.to_string_lossy(), to_file_name(path))
-                }
-            } else {
-                to_file_name(path)
-            };
+            let key = relative_key(relative_path);
 
             Some((key, path.to_path_buf()))
         })
@@ -88,4 +80,43 @@ fn to_file_name(path: &Path) -> String {
     path.file_name()
         .map(|name| name.to_string_lossy().trim_end_matches(".md").to_string())
         .unwrap_or_default()
+}
+
+fn relative_key(path: &Path) -> String {
+    let parent = path.parent().unwrap_or(Path::new(""));
+    let file_name = to_file_name(path);
+
+    if parent.as_os_str().is_empty() {
+        return file_name;
+    }
+
+    let parent_key = parent
+        .iter()
+        .map(|part| part.to_string_lossy())
+        .collect::<Vec<_>>()
+        .join("/");
+
+    format!("{}/{}", parent_key, file_name)
+}
+
+#[cfg(all(test, windows))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn walk_md_paths_normalizes_nested_keys_to_forward_slashes() {
+        let temp_dir = tempfile::TempDir::new().expect("temp dir");
+        let nested = temp_dir.path().join("sub").join("dir");
+
+        fs::create_dir_all(&nested).expect("create nested dir");
+        fs::write(nested.join("note.md"), "# title").expect("write note");
+
+        let mut paths = walk_md_paths(temp_dir.path());
+        paths.sort_by(|a, b| a.0.cmp(&b.0));
+
+        assert_eq!(
+            paths,
+            vec![("sub/dir/note".to_string(), nested.join("note.md"))]
+        );
+    }
 }

--- a/crates/liwe/src/markdown/reader.rs
+++ b/crates/liwe/src/markdown/reader.rs
@@ -411,29 +411,7 @@ impl MarkdownEventsReader {
     }
 
     fn to_inline_range(&self, range: Range<usize>) -> InlineRange {
-        let mut start = 0;
-        let mut start_char = 0;
-        let mut end = 0;
-        let mut end_char = 0;
-
-        for (line, &line_start) in self.line_starts.iter().enumerate() {
-            if line_start <= range.start {
-                start = line;
-                start_char = range.start - line_start;
-            }
-            if line_start <= range.end {
-                end = line;
-                end_char = range.end - line_start;
-            }
-        }
-
-        Position {
-            line: start,
-            character: start_char,
-        }..Position {
-            line: end,
-            character: end_char,
-        }
+        self.byte_offset_to_position(range.start)..self.byte_offset_to_position(range.end)
     }
 
     fn to_line_range(&self, range: Range<usize>) -> LineRange {
@@ -454,6 +432,28 @@ impl MarkdownEventsReader {
         }
 
         start..end
+    }
+
+    fn byte_offset_to_position(&self, offset: usize) -> Position {
+        let content = self.content.as_ref().expect("content to be set");
+        let mut line = 0;
+        let mut line_start = 0;
+
+        for (idx, &start) in self.line_starts.iter().enumerate() {
+            if start <= offset {
+                line = idx;
+                line_start = start;
+            } else {
+                break;
+            }
+        }
+
+        let character = content[line_start..offset]
+            .chars()
+            .map(|ch| ch.len_utf16())
+            .sum();
+
+        Position { line, character }
     }
 }
 
@@ -599,6 +599,23 @@ mod tests {
         ];
 
         assert_eq!(expected, actual);
+    }
+
+    #[test]
+    fn test_wiki_link_position_inside_cjk_text_uses_utf16_columns() {
+        let content = "新西兰旅行，四月最后一个周末。[[travel-2025-beijing]]";
+        let mut reader = MarkdownEventsReader::new();
+        let actual = reader.read(content);
+
+        let DocumentBlock::Para(para) = &actual[0] else {
+            panic!("expected paragraph");
+        };
+
+        let DocumentInline::Link(link) = &para.inlines[1] else {
+            panic!("expected link");
+        };
+
+        assert_eq!(link.inline_range.start, Position { line: 0, character: 15 });
     }
 
     #[test]

--- a/crates/liwe/src/model/document.rs
+++ b/crates/liwe/src/model/document.rs
@@ -142,7 +142,6 @@ impl DocumentBlock {
             DocumentBlock::Table(table) => {
                 let mut result = Vec::new();
 
-
                 let header_text = table
                     .header
                     .iter()
@@ -164,7 +163,6 @@ impl DocumentBlock {
                         .join(" | ");
                     result.push(format!("| {} |", separator));
                 }
-
 
                 for row in &table.rows {
                     let row_text = row
@@ -407,6 +405,12 @@ impl DocumentBlock {
             DocumentBlock::Plain(plain) => plain.inlines.clone(),
             DocumentBlock::Para(para) => para.inlines.clone(),
             DocumentBlock::Header(header) => header.inlines.clone(),
+            DocumentBlock::Table(table) => table
+                .header
+                .iter()
+                .chain(table.rows.iter().flatten())
+                .flat_map(|cell| cell.iter().cloned())
+                .collect(),
             _ => vec![],
         }
     }
@@ -662,22 +666,18 @@ impl DocumentInline {
 
     pub fn key_range(&self) -> Option<InlineRange> {
         match self {
-            DocumentInline::Link(link) => {
-                Some(InlineRange {
-                    start: Position {
-                        line: link.inline_range.start.line,
+            DocumentInline::Link(link) => Some(InlineRange {
+                start: Position {
+                    line: link.inline_range.start.line,
 
-                        character: link.inline_range.start.character
-                            + self.to_plain_text().len()
-                            + 3,
-                    },
-                    end: Position {
-                        line: link.inline_range.end.line,
+                    character: link.inline_range.start.character + self.to_plain_text().len() + 3,
+                },
+                end: Position {
+                    line: link.inline_range.end.line,
 
-                        character: link.inline_range.end.character - 1,
-                    },
-                })
-            }
+                    character: link.inline_range.end.character - 1,
+                },
+            }),
             _ => None,
         }
     }

--- a/crates/liwe/src/parser.rs
+++ b/crates/liwe/src/parser.rs
@@ -54,13 +54,24 @@ impl Parser {
             let url_part = &line[absolute_start..];
 
             let end = url_part
-                .find(|c: char| c.is_whitespace() || c == ')' || c == ']' || c == '>' || c == '"' || c == '\'')
+                .find(|c: char| {
+                    c.is_whitespace() || c == ')' || c == ']' || c == '>' || c == '"' || c == '\''
+                })
                 .unwrap_or(url_part.len());
 
             let url = &url_part[..end];
             let absolute_end = absolute_start + end;
+            let utf16_start = line[..absolute_start]
+                .chars()
+                .map(|ch| ch.len_utf16())
+                .sum::<usize>();
+            let utf16_end = utf16_start
+                + line[absolute_start..absolute_end]
+                    .chars()
+                    .map(|ch| ch.len_utf16())
+                    .sum::<usize>();
 
-            if char_pos >= absolute_start && char_pos < absolute_end {
+            if char_pos >= utf16_start && char_pos < utf16_end {
                 return Some(url.to_string());
             }
 
@@ -75,6 +86,11 @@ impl Parser {
 mod tests {
     use super::*;
     use indoc::indoc;
+
+    fn utf16_offset_of(text: &str, needle: &str) -> usize {
+        let byte_offset = text.find(needle).expect("needle to exist");
+        text[..byte_offset].chars().map(|ch| ch.len_utf16()).sum()
+    }
 
     #[test]
     fn link_in_paragraph() {
@@ -193,5 +209,98 @@ mod tests {
             Some("https://example.com".to_string()),
             parser.url_at((0, 3).into())
         );
+    }
+
+    #[test]
+    fn wiki_link_after_cjk_text() {
+        let parser = Parser::new(
+            "新西兰旅行，四月最后一个周末。[[travel-2025-beijing]]",
+            &MarkdownOptions::default(),
+            crate::markdown::MarkdownReader::new(),
+        );
+
+        assert_eq!(
+            Some("travel-2025-beijing".to_string()),
+            parser.url_at((0, 19).into())
+        );
+    }
+
+    #[test]
+    fn bare_url_after_emoji_uses_utf16_columns() {
+        let parser = Parser::new(
+            "Plan 🧭 https://example.com",
+            &MarkdownOptions::default(),
+            crate::markdown::MarkdownReader::new(),
+        );
+
+        assert_eq!(
+            Some("https://example.com".to_string()),
+            parser.url_at((0, 8).into())
+        );
+    }
+
+    #[test]
+    fn multiple_wiki_links_inside_complex_unicode_line() {
+        let line = "\"新西兰旅行🗺️，四月最后一个周末（2025-04-26～2025-04-27）｜天气：12°C～18°C，风速≈7㎧；预算 NZ$2,888.50；同行者：张三／Alice／λ-user。备注：试试 Māori 美食、温泉♨️、观星🌌；关键词：CJK混排「漢字かなカナ한글」，Unicode：Ω≈ç√∫˜µ≤≥÷，数学：∀x∈ℝ,f(x)=x²→∞，Emoji：👨🏽‍💻🧋🐑🇳🇿，全角／半角：ＡBC123；引用：『人生は旅である』；路径：C:\\旅程\\NZ\\照片📷\\；标签：#旅行 #测试 [[travel-2025-beijing]] [[北京-旅行🧳]]\"";
+        let parser = Parser::new(
+            line,
+            &MarkdownOptions::default(),
+            crate::markdown::MarkdownReader::new(),
+        );
+
+        assert_eq!(
+            Some("travel-2025-beijing".to_string()),
+            parser.url_at((0, utf16_offset_of(line, "[[travel-2025-beijing]]") + 2).into())
+        );
+        assert_eq!(
+            Some("北京 - 旅行🧳".to_string()),
+            parser.url_at((0, utf16_offset_of(line, "[[北京 - 旅行🧳]]") + 2).into())
+        );
+    }
+
+    #[test]
+    fn wiki_link_inside_table_row() {
+        let parser = Parser::new(
+            indoc! {"
+                # diary
+
+                | 日 | [[2026-05-23]] | [[2026-05-25]] |
+                | -- | -- | -- |
+                | 月 | [[2026-05-01]] | [[2026-06-01]] |
+            "},
+            &MarkdownOptions::default(),
+            crate::markdown::MarkdownReader::new(),
+        );
+
+        assert_eq!(Some("2026-05-23".to_string()), parser.url_at((2, 8).into()));
+        assert_eq!(
+            Some("2026-05-25".to_string()),
+            parser.url_at((2, 25).into())
+        );
+    }
+
+    #[test]
+    fn wiki_link_with_heading_fragment_keeps_fragment() {
+        let parser = Parser::new(
+            "[[2025-02-19#就一瞬间]]",
+            &MarkdownOptions::default(),
+            crate::markdown::MarkdownReader::new(),
+        );
+
+        assert_eq!(
+            Some("2025-02-19#就一瞬间".to_string()),
+            parser.url_at((0, 2).into())
+        );
+    }
+
+    #[test]
+    fn embedded_wiki_link_is_not_reported_as_url() {
+        let parser = Parser::new(
+            "![[quote-life-one-moment#quote]]",
+            &MarkdownOptions::default(),
+            crate::markdown::MarkdownReader::new(),
+        );
+
+        assert_eq!(None, parser.url_at((0, 1).into()));
     }
 }


### PR DESCRIPTION
fixed #296 

<img width="1920" height="1050" alt="67518abb7beb9d46fe93eb211b1156b7" src="https://github.com/user-attachments/assets/e9199683-34e6-48a6-9787-4a7dffbffe65" />

 

This PR fixes two issues in IWE:

### 1. Windows path and encoding fixes

* Fixed path concatenation issues on Windows.
* Resolved character encoding problems affecting file parsing.

### 2. Bidirectional link parsing fixes

* Fixed failures when parsing bidirectional links inside Markdown tables.
* Corrected parsing for section-anchored links such as `[[A#B]]`.

**Examples**

Bidirectional links inside tables are now correctly parsed:

```md
| Topic | Reference |
|-------|------------|
| Test  | [[NoteA]]  |
```

Section-anchored links are now handled correctly:

```md
[[A#B]]
```

Previously, links containing hashtags could be parsed incorrectly.



## Note

This PR includes AI-generated code that I manually reviewed and tested against my personal knowledge base. From my testing, the implementation appears to resolve the issues described above.

However, I have some concerns about the code quality and potential regression risks. I was unable to validate the changes across broader environments or platforms, so I cannot fully guarantee the robustness of the implementation.

I recommend that the maintainers review the logic carefully and, if necessary, reimplement parts of the solution using their own tooling or preferred approach. This PR can also be treated as a reference implementation for reproducing and addressing the issues.

I strongly recommend that you construct a robust test set for end-to-end testing, as it will facilitate subsequent implementation, because my implementation is relatively somewhat ad hoc.