### PR TITLE
fix: Normalize fragment-only links, ordered list spacing, and table trailing newlines

### DIFF
--- a/crates/iwes/tests/change_list_type_test.rs
+++ b/crates/iwes/tests/change_list_type_test.rs
@@ -11,8 +11,8 @@ fn change_to_ordered() {
             "},
         0,
         indoc! {"
-            1.  test
-            2.  test2
+            1. test
+            2. test2
         "},
         "Change to ordered list",
     );
@@ -22,8 +22,8 @@ fn change_to_ordered() {
 fn change_to_bullet() {
     assert_list_change(
         indoc! {"
-            1.  test
-            2.  test2
+            1. test
+            2. test2
             "},
         0,
         indoc! {"

--- a/crates/iwes/tests/sort_test.rs
+++ b/crates/iwes/tests/sort_test.rs
@@ -168,9 +168,9 @@ fn sort_ordered_list() {
     .code_action(
         uri(1).to_code_action_params(0, "custom.sort"),
         vec![uri(1).to_edit(indoc! {"
-                1.  apple
-                2.  banana
-                3.  zebra
+                1. apple
+                2. banana
+                3. zebra
                 "})]
         .to_workspace_edit()
         .to_code_action("Sort", "custom.sort"),

--- a/crates/liwe/CHANGELOG.md
+++ b/crates/liwe/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fragment-only links like `[text](#header)` no longer produce `[text](.md#header)` when `refs_extension` is set
+- Ordered list items use single space after marker (`1. item` instead of `1.  item`)
+- Tables no longer produce extra trailing blank line
+
 ## [0.1.9](https://github.com/iwe-org/iwe/compare/liwe-v0.1.8...liwe-v0.1.9) - 2026-05-27
 
 ### Fixed

--- a/crates/liwe/src/model/document.rs
+++ b/crates/liwe/src/model/document.rs
@@ -545,7 +545,7 @@ impl DocumentInline {
             DocumentInline::LineBreak(_) => GraphInline::LineBreak,
             DocumentInline::Link(link) => {
                 let inlines = to_graph_inlines(&link.inlines, relative_to);
-                if model::is_ref_url(&link.target.url) {
+                if model::is_ref_url(&link.target.url) && !link.target.url.starts_with('#') {
                     GraphInline::Reference(Reference {
                         key: Key::from_rel_link_url(&link.target.url, relative_to),
                         text: to_plain_text(&inlines),

--- a/crates/liwe/src/model/graph.rs
+++ b/crates/liwe/src/model/graph.rs
@@ -193,7 +193,7 @@ impl GraphBlock {
             }
             GraphBlock::Table(_, _, _) => {
                 let writer = MarkdownWriter::new(options.clone());
-                format!("{}\n", writer.write(vec![self.clone()]))
+                writer.write(vec![self.clone()])
             }
         }
     }
@@ -205,12 +205,7 @@ fn ordered_prefix_indent(item_count: usize, formatting: &FormattingOptions) -> u
     } else {
         1
     };
-    let prefix = format!(
-        "{}{}{}",
-        last,
-        formatting.ordered_list_token_char(),
-        if last > 9 { "" } else { " " }
-    );
+    let prefix = format!("{}{}", last, formatting.ordered_list_token_char());
     prefix.len() + 1
 }
 
@@ -416,12 +411,7 @@ fn left_pad_and_prefix(text: &str, list_token: &str) -> String {
 }
 
 fn left_pad_and_prefix_num(text: &str, num: usize, ordered_list_token: char) -> String {
-    let prefix = format!(
-        "{}{}{}",
-        num,
-        ordered_list_token,
-        if num > 9 { "" } else { " " }
-    );
+    let prefix = format!("{}{}", num, ordered_list_token);
     let mut result = String::new();
     for (n, line) in text.lines().enumerate() {
         if line.is_empty() {
@@ -697,7 +687,7 @@ fn append_refs_extension(url: &str, extension: &str) -> String {
         None => (url, None),
     };
 
-    let new_path = if has_file_extension(path) {
+    let new_path = if path.is_empty() || has_file_extension(path) {
         path.to_string()
     } else {
         format!("{path}{extension}")
@@ -864,15 +854,15 @@ pub mod tests {
         ])];
         assert_eq!(
             indoc! {"
-                1.  item
-                2.  item
-                3.  item
-                4.  item
-                5.  item
-                6.  item
-                7.  item
-                8.  item
-                9.  item
+                1. item
+                2. item
+                3. item
+                4. item
+                5. item
+                6. item
+                7. item
+                8. item
+                9. item
                 10. item
                 "},
             blocks_to_markdown(&list, &MarkdownOptions::default()),
@@ -887,9 +877,9 @@ pub mod tests {
         ]])];
         assert_eq!(
             indoc! {"
-                1.  item1
+                1. item1
 
-                    para
+                   para
                 "},
             blocks_to_markdown(&list, &MarkdownOptions::default()),
         );

--- a/crates/liwe/tests/formatting_test.rs
+++ b/crates/liwe/tests/formatting_test.rs
@@ -135,8 +135,8 @@ fn default_rule_token() {
 fn ordered_list_with_dot() {
     compare(
         indoc! {"
-        1.  item1
-        2.  item2
+        1. item1
+        2. item2
         "},
         indoc! {"
         1. item1
@@ -150,8 +150,8 @@ fn ordered_list_with_dot() {
 fn ordered_list_with_paren() {
     compare(
         indoc! {"
-        1)  item1
-        2)  item2
+        1) item1
+        2) item2
         "},
         indoc! {"
         1. item1
@@ -168,9 +168,9 @@ fn ordered_list_with_paren() {
 fn increment_ordered_list_bullets_true() {
     compare(
         indoc! {"
-        1.  item1
-        2.  item2
-        3.  item3
+        1. item1
+        2. item2
+        3. item3
         "},
         indoc! {"
         1. item1
@@ -185,9 +185,9 @@ fn increment_ordered_list_bullets_true() {
 fn increment_ordered_list_bullets_false() {
     compare(
         indoc! {"
-        1.  item1
-        1.  item2
-        1.  item3
+        1. item1
+        1. item2
+        1. item3
         "},
         indoc! {"
         1. item1

--- a/crates/liwe/tests/links_test.rs
+++ b/crates/liwe/tests/links_test.rs
@@ -365,6 +365,26 @@ fn normalization_preserves_non_md_extension_in_subdir() {
     assert_str_eq!("[link text](bar/foo.html)\n", normalized);
 }
 
+#[test]
+fn fragment_only_link_preserved() {
+    setup();
+
+    let mut graph = Graph::new_with_options(MarkdownOptions {
+        refs_extension: ".md".to_string(),
+        ..Default::default()
+    });
+
+    graph.from_markdown(
+        "key".into(),
+        "# title\n\n[text](#title)\n",
+        MarkdownReader::new(),
+    );
+
+    let normalized = graph.to_markdown(&"key".into());
+
+    assert_str_eq!("# title\n\n[text](#title)\n", normalized);
+}
+
 fn normalize(expected: &str, denormalized: &str) {
     setup();
 

--- a/crates/liwe/tests/normalization_lists.rs
+++ b/crates/liwe/tests/normalization_lists.rs
@@ -105,8 +105,8 @@ fn normalization_dual_dash_three_items_list_item() {
 fn normalization_dual_dash_two_items_ordered_list_item() {
     compare(
         indoc! {"
-        1.  item 1
-        2.  item 2
+        1. item 1
+        2. item 2
         "},
         indoc! {"
         1.  1.  item 1
@@ -139,7 +139,7 @@ fn normalization_list_items_with_text() {
 fn normalization_numbered_list_item() {
     compare(
         indoc! {"
-        1.  item 1
+        1. item 1
         "},
         indoc! {"
         1.  item 1
@@ -151,8 +151,8 @@ fn normalization_numbered_list_item() {
 fn normalization_numbered_list_2_items() {
     compare(
         indoc! {"
-        1.  item 1
-        2.  item 1
+        1. item 1
+        2. item 1
         "},
         indoc! {"
         1.  item 1
@@ -165,8 +165,8 @@ fn normalization_numbered_list_2_items() {
 fn normalization_numbered_list_in_list() {
     compare(
         indoc! {"
-        1.  item 1
-            1.  item 1
+        1. item 1
+           1. item 1
         "},
         indoc! {"
         1.  item 1
@@ -179,9 +179,9 @@ fn normalization_numbered_list_in_list() {
 fn normalization_numbered_list_with_para() {
     compare(
         indoc! {"
-        1.  item 1
+        1. item 1
 
-            para
+           para
         "},
         indoc! {"
         1.  item 1
@@ -293,7 +293,7 @@ fn normalization_two_list_with_sub_items() {
 fn normalization_ordered_list() {
     compare(
         indoc! {"
-        1.  list item
+        1. list item
         "},
         indoc! {"
         1. list item
@@ -305,8 +305,8 @@ fn normalization_ordered_list() {
 fn normalization_ordered_list_with_sub_list() {
     compare(
         indoc! {"
-        1.  list item
-            - sub list item
+        1. list item
+           - sub list item
         "},
         indoc! {"
         1. list item
@@ -321,7 +321,7 @@ fn normalization_ordered_list_and_bullet_list() {
         indoc! {"
         - sub list item
 
-        1.  list item
+        1. list item
         "},
         indoc! {"
         - sub list item

--- a/crates/liwe/tests/normalization_misc.rs
+++ b/crates/liwe/tests/normalization_misc.rs
@@ -264,7 +264,6 @@ fn table() {
         | header |
         | ------ |
         | row    |
-
     "},
         indoc! {"
         para
@@ -286,7 +285,6 @@ fn two_column_table() {
         | header1 | header2 |
         | ------- | ------- |
         | row1    | row2    |
-
     "},
         indoc! {"
         para
@@ -307,7 +305,6 @@ fn table_with_alignment() {
         |:-----|:------:|------:|
         | a    |   b    |     c |
         | long |  text  |  here |
-
     "},
         indoc! {"
         | left | center | right |
@@ -326,7 +323,6 @@ fn table_with_pipe_in_code() {
         | header   |
         | -------- |
         | `a \\| b` |
-
     "},
         indoc! {"
         | header |


### PR DESCRIPTION
Fixes three markdown normalization issues reported in #294