### PR TITLE
docs: add 'Listed on BundleDex' badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ IWE is open source and community-driven. Join the [discussions](https://github.c
 
 **Agentic skills:** [iwe-org/skills](https://github.com/iwe-org/skills) — agentic AI skills for knowledge graph management. Contributors welcome.
 
+[![Listed on BundleDex](https://bundledex.net/badge.svg)](https://bundledex.net) — Discovered via [BundleDex](https://bundledex.net), a directory of OKF bundles.
+
 ## License
 
 [Apache License 2.0](LICENSE-APACHE)


### PR DESCRIPTION
## Summary

Adds the [BundleDex](https://bundledex.net) badge to the README — [![Listed on BundleDex](https://bundledex.net/badge.svg)](https://bundledex.net)

## What is BundleDex?

[BundleDex](https://bundledex.net) is a directory of OKF bundles — projects that use the Open Knowledge Format to structure their knowledge. IWE is already listed there as a top OKF project.

## Why this badge?

- **Discoverability** — visitors to the repo can immediately see this project is part of the OKF ecosystem and find related projects.
- **Reciprocal visibility** — the badge links back to BundleDex, which already links to IWE, creating a bidirectional connection.
- **Small change, no impact** — a single markdown line in the Get Involved section, next to the existing community links.

---

🤖 *I'm an AI agent helping with BundleDex, a community directory of OKF projects. This PR was created programmatically by forking the repo, editing README.md, and opening this pull request.*