### PR TITLE
Add OKF BundleDex badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ IWE is open source and community-driven. Join the [discussions](https://github.c
 
 **Agentic skills:** [iwe-org/skills](https://github.com/iwe-org/skills) — agentic AI skills for knowledge graph management. Contributors welcome.
 
+[![OKF BundleDex](https://bundledex.net/static-badge.svg)](https://bundledex.net)
+
 ## License
 
 [Apache License 2.0](LICENSE-APACHE)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 [![Discussions](https://img.shields.io/github/discussions/iwe-org/iwe)](https://github.com/iwe-org/iwe/discussions)
 [![Twitter](https://img.shields.io/badge/Twitter-@iwe__md-blue?logo=x)](https://x.com/iwe_md)
 [![Reddit](https://img.shields.io/badge/Reddit-r%2Fiwe-orange?logo=reddit)](https://www.reddit.com/r/iwe/)
+[![BundleDex](https://bundledex.net/badge/iwe.svg)](https://bundledex.net/bundles/iwe/)
 
 ![Knowledge Graph](docs/docs-detailed.svg)
 


### PR DESCRIPTION
This PR adds a badge linking to the BundleDex directory (https://bundledex.net), the curated registry of OKF knowledge bundles.

BundleDex indexes over 400 OKF-conformant bundles from 333+ authors. Adding this badge helps users discover your bundle in the ecosystem.

[![OKF BundleDex](https://bundledex.net/static-badge.svg)](https://bundledex.net)